### PR TITLE
Exclude PDFs and static assets from sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,10 @@ defaults:
     values:
       image: /assets/images/logos/1/kavehrs.jpg
   - scope:
+      path: "assets"
+    values:
+      sitemap: false
+  - scope:
       path: ""
       type: blog
     values:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After the full SEO re-audit, PDFs under `/assets` were still listed in `sitemap.xml`. This excludes the `assets/` path from the sitemap so only HTML pages remain.

## Test plan
- [x] Local sitemap reduced to 23 HTML URLs
- [ ] Verify live sitemap after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

