### PR TITLE
Justify Persian RTL and English LTR article text

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -48,7 +48,45 @@ article img {
     margin: 0 auto;
 }
 
-/* کد و ترمینال همیشه LTR بمانند حتی در صفحات RTL */
+/* جاستیفای متن‌ها بر اساس زبان/جهت صفحه */
+html[dir="rtl"] article,
+html[dir="rtl"] article p,
+html[dir="rtl"] article li,
+html[dir="rtl"] article blockquote {
+    text-align: justify;
+    text-align-last: right;
+}
+
+html[dir="ltr"] article,
+html[dir="ltr"] article p,
+html[dir="ltr"] article li,
+html[dir="ltr"] article blockquote {
+    text-align: justify;
+    text-align-last: left;
+}
+
+/* عنوان‌ها هم با جهت صفحه هم‌راستا بمانند */
+html[dir="rtl"] article h1,
+html[dir="rtl"] article h2,
+html[dir="rtl"] article h3,
+html[dir="rtl"] article h4,
+html[dir="rtl"] article h5,
+html[dir="rtl"] article h6 {
+    text-align: right;
+    text-align-last: right;
+}
+
+html[dir="ltr"] article h1,
+html[dir="ltr"] article h2,
+html[dir="ltr"] article h3,
+html[dir="ltr"] article h4,
+html[dir="ltr"] article h5,
+html[dir="ltr"] article h6 {
+    text-align: left;
+    text-align-last: left;
+}
+
+/* کد و ترمینال همیشه LTR و چپ‌چین بمانند حتی در صفحات RTL */
 article pre,
 article code,
 article kbd,
@@ -56,11 +94,14 @@ article samp {
     direction: ltr;
     unicode-bidi: isolate;
     text-align: left;
+    text-align-last: left;
 }
 
 article pre {
     overflow-x: auto;
     max-width: 100%;
+    text-align: left;
+    text-align-last: left;
 }
 
 /* تنظیم عنوان و توضیحات هدر برای نمایش در یک خط */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Persian/RTL pages: `text-align: justify` with `text-align-last: right`
- English/LTR pages: `text-align: justify` with `text-align-last: left`
- Code blocks remain LTR left-aligned
- Headings follow page direction (right for FA, left for EN)

## Test plan
- [x] Jekyll build includes justify CSS rules
- [x] Home stays `dir=ltr`; blog/logbook stay `dir=rtl`
- [ ] Verify live CSS after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

