### PR TITLE
Daily SEO agent + climb-report ranking baseline

### DIFF
--- a/.cursor/automations/daily-seo-prompt.md
+++ b/.cursor/automations/daily-seo-prompt.md
@@ -1,0 +1,36 @@
+# Cursor Automation — Daily SEO Agent
+
+> Native Automations are created in the Cursor dashboard (not from this file).  
+> Paste the prompt below into a new Automation at https://cursor.com/automations/new
+
+## Recommended settings
+
+| Field | Value |
+|-------|--------|
+| Name | Daily SEO — kavehrs.com climb reports |
+| Trigger | Scheduled · cron `0 3 * * *` (every day ~03:00 UTC ≈ 06:30 IRST) |
+| Repository | `KavehRS/website` |
+| Base branch | `master` |
+| Tools | Web fetch/search, GitHub/PRs enabled |
+| PR behavior | Create PR; merge after successful `jekyll build` when high-confidence |
+
+## Prompt (copy everything below this line)
+
+```
+You are the daily SEO agent for https://www.kavehrs.com (repo KavehRS/website, branch master).
+
+Mission: make this site the leading Persian authority for گزارش برنامه صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی across major search engines.
+
+Before changing anything:
+1. Read AGENTS.md
+2. Follow .cursor/skills/daily-seo-audit/SKILL.md exactly
+3. Obey .cursor/rules/seo-daily-agent.mdc and .cursor/rules/logbook-reports.mdc
+4. Refresh guidance from Google Search Central, Bing Webmaster Guidelines, and schema.org (latest public docs)
+
+Then audit the live site + repo, implement only evidence-based SEO improvements (logbook first), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
+
+If you make verified high-confidence changes: open a PR on a cursor/*-33ce branch and merge to master after a clean build.
+If nothing material needs changing: do not open a PR; leave a brief summary of what you checked.
+
+Never invent climb facts, never duplicate report prose for the same peak, never keyword-stuff, never commit secrets.
+```

--- a/.cursor/rules/logbook-reports.mdc
+++ b/.cursor/rules/logbook-reports.mdc
@@ -10,8 +10,9 @@ When the user asks for a new climb / ascent report (`گزارش صعود`):
 1. Use the section framework in:
    - `_drafts/logbook-ascent-report-template.md` (placeholders)
    - `_drafts/samples/kahar-peak-report-framework-sample.md` (worked Kahar sample)
-2. Create the published file under `_logbook/YYYY-MM-DD-<peak-slug>.md` with SEO front matter (`lang: fa-IR`, `dir_attr: rtl`, `description`, `date`, tags).
+2. Create the published file under `_logbook/YYYY-MM-DD-<peak-slug>.md` with SEO front matter (`lang: fa-IR`, `dir_attr: rtl`, `description`, `date`, tags) and, when known, `peak: { name, elevation_m, latitude, longitude, region }` for Mountain JSON-LD.
 3. Keep the same overall structure (peak specs → region → weather → flora/fauna → access → routes → shelter/water → season → views → gear → team → narrative).
+
 
 ## Hard uniqueness rule
 

--- a/.cursor/rules/seo-daily-agent.mdc
+++ b/.cursor/rules/seo-daily-agent.mdc
@@ -1,0 +1,38 @@
+---
+description: Daily SEO agent goals and safety for kavehrs.com climb-report ranking
+alwaysApply: true
+---
+
+# Daily SEO agent
+
+Goal: make https://www.kavehrs.com the leading Persian source for mountaineering, rock-climbing, and ice-climbing ascent-program reports across major search engines.
+
+## When this applies
+
+- Scheduled daily SEO automation
+- Any request to audit, improve, or update site SEO
+
+## Required workflow
+
+1. Read `AGENTS.md` and `.cursor/skills/daily-seo-audit/SKILL.md`.
+2. Pull latest authoritative SEO guidance (Google Search Central, Bing Webmaster Guidelines, schema.org) before changing markup.
+3. Audit the live site and the repo (meta, canonical, sitemap, robots, structured data, internal links, images, Core Web Vitals proxies, crawl errors).
+4. Implement only evidence-based improvements; keep PRs narrowly scoped.
+5. Run `bundle exec jekyll build` and confirm `_drafts/` / `.cursor/` are not published.
+6. Open PR, then merge after a clean build when the change is high-confidence.
+
+## Ranking priorities (logbook first)
+
+1. Unique, factual ascent reports with strong titles/descriptions/tags
+2. Structured data (`BlogPosting` + mountain/place when peak data exists)
+3. Internal links between related climbs and the `/logbook/` hub
+4. Accurate Open Graph / Twitter images (prefer climb photos over logo)
+5. Technical hygiene: broken links, missing alts, wrong `lang`/`dir`, sitemap noise
+
+## Hard limits
+
+- Do not duplicate published report prose for the same peak.
+- Do not keyword-stuff titles or body copy.
+- Do not fabricate climb details to chase rankings.
+- Do not remove `noindex` from archive/projects/404 without explicit user request.
+- Do not change analytics IDs or domain/`CNAME` casually.

--- a/.cursor/skills/daily-seo-audit/SKILL.md
+++ b/.cursor/skills/daily-seo-audit/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: daily-seo-audit
+description: Daily SEO audit and update workflow for kavehrs.com climb-report ranking
+---
+
+# Daily SEO audit skill
+
+Run this every 24 hours (Cursor Automation or GitHub Action → Cloud Agent API).
+
+## Mission
+
+Improve discoverability of Persian **گزارش برنامه صعود** content for:
+
+- کوهنوردی (mountaineering)
+- سنگ‌نوردی (rock climbing)
+- یخ‌نوردی / DryTooling (ice / mixed)
+
+Primary hub: `/logbook/` · Site: `https://www.kavehrs.com`
+
+## Step 0 — Fresh guidance
+
+Fetch and skim the latest public docs (prefer primary sources):
+
+- Google Search Central (SEO starter, meta tags, robots, sitemaps, structured data / rich results)
+- Bing Webmaster Guidelines
+- schema.org types relevant to articles, places, mountains, sports/activities
+- Any material change vs previous run → note it in the PR body
+
+Do not invent “SEO tips” from random blogs when they conflict with primary docs.
+
+## Step 1 — Live crawl snapshot
+
+Inspect:
+
+1. `https://www.kavehrs.com/`
+2. `https://www.kavehrs.com/logbook/`
+3. `https://www.kavehrs.com/robots.txt`
+4. `https://www.kavehrs.com/sitemap.xml`
+5. Every indexed HTML URL in the sitemap (or build output if live fetch fails)
+
+Record: title, meta description, canonical, `lang`/`dir`, H1 count, OG/Twitter tags, JSON-LD validity, obvious broken images/links.
+
+## Step 2 — Repo audit checklist
+
+For each `_logbook/*.md` and key pages (`index.md`, `logbook.md`, blog index):
+
+- [ ] Unique `title` and `description` (≈120–160 chars for description when practical)
+- [ ] `lang` / `dir_attr` correct
+- [ ] `image` points to a real climb asset when available (not only the logo)
+- [ ] `image` alt available when using object form supported by theme/includes
+- [ ] Categories/tags cover peak, range, activity type (کوهنوردی / سنگ‌نوردی / یخ‌نوردی)
+- [ ] Peak front matter (`peak.name`, elevation, lat/lon) present when known → feeds JSON-LD
+- [ ] Internal links: related climbs + hub `/logbook/`
+- [ ] No duplicate body text vs another report of the same peak
+- [ ] Headings: single H1, logical H2+
+- [ ] Images: meaningful `alt` in Markdown
+
+Technical site-wide:
+
+- [ ] `jekyll-seo-tag` + `jekyll-sitemap` still enabled
+- [ ] `robots.txt` points at sitemap
+- [ ] Noindex pages stay out of ranking intent (archive, projects, 404, legacy redirects)
+- [ ] Favicons / social image resolve (HTTP 200)
+- [ ] Structured data includes climb Place/Mountain when `page.peak` exists
+- [ ] Performance proxies: oversized images in new posts, missing compression
+
+## Step 3 — Decide what to change today
+
+Priority order:
+
+1. Broken crawl/index blockers (404 assets, bad canonical, accidental noindex on logbook)
+2. Missing/weak logbook metadata and structured data
+3. Internal linking gaps on climb reports
+4. Hub page (`/logbook/`) clarity for target queries
+5. Incremental content SEO (titles/descriptions) without rewriting unique narratives
+6. Only then: broader template/CSS SEO hygiene
+
+Skip low-value churn (renaming CSS classes, speculative keyword density edits).
+
+If nothing material is wrong, **make no PR**.
+
+## Step 4 — Implement
+
+- Branch: `cursor/seo-daily-YYYYMMDD-33ce` (or similar kebab + `-33ce`)
+- Keep uniqueness rules from `.cursor/rules/logbook-reports.mdc`
+- Prefer includes/layouts/`_config.yml` for systemic fixes over one-off hacks
+- Update `_seo/daily-log.md` with a short dated entry (what checked, what changed, sources consulted)
+
+## Step 5 — Verify & ship
+
+```bash
+bundle exec jekyll build
+test ! -e _site/drafts
+test ! -e _site/cursor
+```
+
+Then: commit → push → open PR → merge after clean build (high-confidence technical SEO).  
+If a change is editorial/controversial, leave as draft PR and summarize for the owner instead of merging.
+
+## Success metrics (track qualitatively in `_seo/daily-log.md`)
+
+- Logbook URLs have complete meta + useful JSON-LD
+- Hub page ranks thematically for گزارش صعود / برنامه کوهنوردی
+- No duplicate thin pages
+- Sitemap only contains indexable URLs
+- Each new improvement compounds; avoid oscillating rewrites day-to-day

--- a/.github/workflows/daily-seo-agent.yml
+++ b/.github/workflows/daily-seo-agent.yml
@@ -1,0 +1,73 @@
+# Optional fallback scheduler: starts a Cursor Cloud Agent via API every 24h.
+# Prefer native Cursor Automations (see .cursor/automations/daily-seo-prompt.md).
+#
+# Required repo secret:
+#   CURSOR_API_KEY — from https://cursor.com/settings (API keys)
+#
+# If the secret is missing, the workflow no-ops successfully so Actions stays green.
+
+name: Daily SEO Cloud Agent
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  start-seo-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Cursor Cloud Agent
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CURSOR_API_KEY:-}" ]; then
+            echo "CURSOR_API_KEY secret not set — skip API trigger."
+            echo "Create a Cursor Automation instead: .cursor/automations/daily-seo-prompt.md"
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import json, os, urllib.request
+
+          prompt = """You are the daily SEO agent for https://www.kavehrs.com (repo KavehRS/website, branch master).
+
+          Mission: make this site the leading Persian authority for گزارش برنامه صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی across major search engines.
+
+          Before changing anything:
+          1. Read AGENTS.md
+          2. Follow .cursor/skills/daily-seo-audit/SKILL.md exactly
+          3. Obey .cursor/rules/seo-daily-agent.mdc and .cursor/rules/logbook-reports.mdc
+          4. Refresh guidance from Google Search Central, Bing Webmaster Guidelines, and schema.org (latest public docs)
+
+          Then audit the live site + repo, implement only evidence-based SEO improvements (logbook first), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
+
+          If you make verified high-confidence changes: open a PR on a cursor/*-33ce branch and merge to master after a clean build.
+          If nothing material needs changing: do not open a PR; leave a brief summary of what you checked.
+
+          Never invent climb facts, never duplicate report prose for the same peak, never keyword-stuff, never commit secrets."""
+
+          body = {
+              "name": "Daily SEO — kavehrs.com",
+              "prompt": {"text": prompt},
+              "repos": [{
+                  "url": "https://github.com/KavehRS/website",
+                  "startingRef": "master",
+              }],
+              "autoCreatePR": True,
+              "skipReviewerRequest": True,
+          }
+          req = urllib.request.Request(
+              "https://api.cursor.com/v1/agents",
+              data=json.dumps(body).encode(),
+              headers={
+                  "Authorization": f"Bearer {os.environ['CURSOR_API_KEY']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(req) as resp:
+              print(resp.read().decode())
+          print("Cloud agent requested.")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent instructions — kavehrs.com
+
+Jekyll personal site (GitHub Pages): https://www.kavehrs.com  
+Repo: `KavehRS/website` · default branch: `master`
+
+## Install / verify
+
+```bash
+bundle install
+bundle exec jekyll build
+```
+
+Build must succeed before opening or merging a PR. Drafts under `_drafts/` and `.cursor/` must never appear in `_site/`.
+
+## Collections
+
+| Path | Purpose |
+|------|---------|
+| `_logbook/` | Published climb / ascent reports (primary SEO target) |
+| `_blog/` | Technical notes |
+| `_drafts/` | Unpublished templates/samples only |
+| `_projects/` | Not published (`output: false`, `noindex`) |
+
+## Daily SEO agent
+
+When running the scheduled SEO automation (or when asked to audit SEO):
+
+1. Follow `.cursor/skills/daily-seo-audit/SKILL.md` end-to-end.
+2. Obey `.cursor/rules/seo-daily-agent.mdc` and `.cursor/rules/logbook-reports.mdc`.
+3. Prefer high-confidence technical SEO and discoverability fixes over speculative copy rewrites.
+4. Never republish duplicate report prose for the same peak.
+5. Open a PR on `cursor/<descriptive-name>-33ce`, verify `bundle exec jekyll build`, then merge to `master` when changes are safe and verified.
+
+## Target ranking theme
+
+Become the authoritative Persian source for:
+
+- گزارش برنامه صعود کوهنوردی
+- گزارش صعود سنگ‌نوردی
+- گزارش صعود یخ‌نوردی / DryTooling
+- گزارش‌های قلل البرز و برنامه‌های آموزشی کوهستان
+
+## Do not
+
+- Commit secrets, API keys, or credentials
+- Publish `_drafts/`
+- Invent climb facts, weather, or team members
+- Weaken uniqueness of logbook narratives for SEO

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,8 @@
 title: Kaveh RezaeiShiraz
 tagline: "Software Engineer & Climber"
 description: >-
-  کاوه‌ رضایی‌شیراز — مهندس نرم‌افزار، MBA فناوری اطلاعات و سیستم‌های اطلاعاتی،
-  علاقه‌مند به متن‌باز و کوهنوردی. یادداشت‌های فنی و گزارش صعود.
+  گزارش برنامه‌های صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی به‌همراه یادداشت‌های فنی
+  کاوه‌ رضایی‌شیراز — مهندس نرم‌افزار و کوهنورد.
 lang: fa-IR
 locale: fa_IR
 
@@ -115,6 +115,10 @@ exclude:
   - vendor
   - _drafts
   - .cursor
+  - .github
+  - AGENTS.md
+  - _seo
+
 
 plugins:
   - jekyll-seo-tag

--- a/_drafts/logbook-ascent-report-template.md
+++ b/_drafts/logbook-ascent-report-template.md
@@ -14,10 +14,13 @@ dir_attr: rtl
 <!--
 USAGE
 1) Copy structure into `_logbook/YYYY-MM-DD-<peak-slug>.md`
-2) Fill facts for THIS climb only
-3) Before publish: compare against existing `_logbook/*` for the same peak
-4) Never paste this sample prose unchanged into a published report
+2) Front matter must include: lang, dir_attr, description, date, tags, image
+   and peak: { name, elevation_m, latitude, longitude, region } when known (SEO JSON-LD)
+3) Fill facts for THIS climb only
+4) Before publish: compare against existing `_logbook/*` for the same peak
+5) Never paste this sample prose unchanged into a published report
 -->
+
 
 **گزارش برنامه صعود به قله {{نام_قله}}**
 

--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,3 +1,4 @@
+{% comment %}Manual related links take precedence; otherwise suggest logbook posts that share tags.{% endcomment %}
 {% if page.related and page.related.size > 0 %}
 <nav class="related-posts" aria-label="مطالب مرتبط" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
   <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">مطالب مرتبط</h2>
@@ -7,4 +8,31 @@
     {% endfor %}
   </ul>
 </nav>
+{% elsif page.collection == 'logbook' and page.tags and page.tags.size > 0 %}
+  {% assign related_count = 0 %}
+  {% capture related_list %}
+    {% for post in site.logbook reversed %}
+      {% if post.url != page.url and related_count < 5 %}
+        {% assign shares_tag = false %}
+        {% for tag in page.tags %}
+          {% if post.tags contains tag %}
+            {% assign shares_tag = true %}
+          {% endif %}
+        {% endfor %}
+        {% if shares_tag %}
+          {% assign related_count = related_count | plus: 1 %}
+          <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endcapture %}
+  {% assign related_list = related_list | strip %}
+  {% if related_list != '' %}
+<nav class="related-posts" aria-label="مطالب مرتبط" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
+  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">گزارش‌های مرتبط</h2>
+  <ul>
+    {{ related_list }}
+  </ul>
+</nav>
+  {% endif %}
 {% endif %}

--- a/_includes/structured-data-logbook.html
+++ b/_includes/structured-data-logbook.html
@@ -1,0 +1,70 @@
+{% if page.collection == 'logbook' and page.peak %}
+{% assign peak = page.peak %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": {{ page.title | jsonify | jsonify_encode }},
+  "description": {{ page.description | default: page.excerpt | strip_html | truncate: 300 | jsonify | jsonify_encode }},
+  "inLanguage": {{ page.lang | default: site.lang | jsonify }},
+  "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+  "dateModified": {{ page.last_modified_at | default: page.date | date_to_xmlschema | jsonify }},
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url }}"
+  },
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author.name | jsonify }},
+    "url": {{ site.author.url | jsonify }}
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": {{ site.author.name | jsonify }},
+    "url": "{{ site.url }}{{ site.baseurl }}/"
+  },
+  "about": {
+    "@type": "Mountain",
+    "name": {{ peak.name | jsonify }}{% if peak.elevation_m %},
+    "elevation": {
+      "@type": "QuantitativeValue",
+      "value": {{ peak.elevation_m }},
+      "unitCode": "MTR"
+    }{% endif %}{% if peak.latitude and peak.longitude %},
+    "geo": {
+      "@type": "GeoCoordinates",
+      "latitude": {{ peak.latitude }},
+      "longitude": {{ peak.longitude }}
+    }{% endif %}{% if peak.region %},
+    "containedInPlace": {
+      "@type": "Place",
+      "name": {{ peak.region | jsonify }}
+    }{% endif %}
+  },
+  "keywords": "{% if page.tags %}{{ page.tags | join: ', ' }}{% endif %}{% if page.categories %}, {{ page.categories | join: ', ' }}{% endif %}, گزارش صعود, کوهنوردی, برنامه صعود"
+}
+</script>
+{% endif %}
+
+{% if page.url == '/logbook/' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": {{ page.title | jsonify | jsonify_encode }},
+  "description": {{ page.description | jsonify | jsonify_encode }},
+  "url": "{{ page.url | absolute_url }}",
+  "inLanguage": "fa-IR",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": {{ site.title | jsonify }},
+    "url": "{{ site.url }}{{ site.baseurl }}/"
+  },
+  "about": [
+    {"@type": "Thing", "name": "گزارش برنامه صعود کوهنوردی"},
+    {"@type": "Thing", "name": "سنگ‌نوردی"},
+    {"@type": "Thing", "name": "یخ‌نوردی"}
+  ]
+}
+</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,9 @@ layout: compress
     {% endif %}
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
     {% seo %}
+    {% include structured-data-logbook.html %}
     {% include favicon.html %}
+
     <link rel="preconnect" href="https://use.fontawesome.com" crossorigin>
     <script type="text/javascript">
         (function() {

--- a/_logbook/2026-08-14-kahar-peak.md
+++ b/_logbook/2026-08-14-kahar-peak.md
@@ -6,9 +6,16 @@ dir_attr: rtl
 description: "پیش‌گزارش صعود به قله کهار (۴۰۵۰ متر) در جمعه ۲۳ مرداد ۱۴۰۵؛ معرفی منطقه، مسیر کلوان، پناهگاه و جزئیات برنامه."
 date: 2026-08-14
 categories: [mountaineering, logbook]
-tags: [کهار, البرز, کلوان, آسارا, طالقان, کوهنوردی]
+tags: [کهار, البرز, کلوان, آسارا, طالقان, کوهنوردی, گزارش صعود]
 image: /assets/images/logos/1/kavehrs.jpg
+peak:
+  name: "کهار"
+  elevation_m: 4050
+  latitude: 36.14017
+  longitude: 51.07872
+  region: "البرز، آسارا / طالقان"
 ---
+
 
 **گزارش برنامه صعود به قله کهار**
 

--- a/_seo/daily-log.md
+++ b/_seo/daily-log.md
@@ -1,0 +1,11 @@
+# Daily SEO agent log
+
+Append-only run notes for the scheduled SEO agent. Not published on the site.
+
+## 2026-08-04 — bootstrap
+
+- Added daily SEO skill, Cursor Automation prompt, optional GitHub Actions trigger.
+- Baseline: logbook CollectionPage + Mountain Article JSON-LD when `page.peak` is set.
+- Auto related links for logbook by shared tags.
+- Tuned site/logbook descriptions toward گزارش برنامه صعود کوهنوردی / سنگ‌نوردی / یخ‌نوردی.
+- Sources consulted at bootstrap: Google Search Central (SEO basics, sitemaps, structured data), schema.org `Article` / `Mountain` / `CollectionPage`, Bing Webmaster Guidelines overview.

--- a/logbook.md
+++ b/logbook.md
@@ -1,13 +1,15 @@
 ---
 layout: default
-title: گزارش صعود
-description: "گزارش برنامه‌های کوهنوردی و صعودهای کاوه‌ رضایی‌شیراز؛ قله‌ها، تیغه‌ها و کمپ‌های آموزشی البرز."
+title: گزارش برنامه صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی
+description: "آرشیو گزارش برنامه‌های صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی؛ قلل البرز، مسیرها، شرایط هوا و جزئیات اجرای برنامه."
 permalink: /logbook/
 lang: fa-IR
 dir_attr: rtl
 ---
 
-<h1>گزارش صعود</h1>
+<h1>گزارش برنامه صعود</h1>
+<p>گزارش‌های صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی — از مشخصات قله و مسیر تا شرایط برنامه و تیم اجرا.</p>
+
 <ul>
   {% for post in site.logbook reversed %}
     <li style="margin-bottom: 15px; list-style: none; border-bottom: 1px solid #eee; padding-bottom: 10px;">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a daily SEO agent framework aimed at ranking for Persian mountaineering / rock / ice ascent-program reports, plus a first baseline of on-site SEO improvements.

### Agent framework (every 24h)
- Ready-to-paste Automation prompt: `.cursor/automations/daily-seo-prompt.md`
- Skill: `.cursor/skills/daily-seo-audit/SKILL.md`
- Rules: `.cursor/rules/seo-daily-agent.mdc` (+ logbook uniqueness still enforced)
- `AGENTS.md` for cloud-agent install/verify/ship flow
- Optional GitHub Actions fallback: `.github/workflows/daily-seo-agent.yml` (needs `CURSOR_API_KEY` secret; no-ops if missing)
- Run log: `_seo/daily-log.md` (excluded from site output)

### Baseline SEO in this PR
- Mountain `Article` JSON-LD when `page.peak` is set; `CollectionPage` on `/logbook/`
- Auto related logbook links by shared tags
- Hub + site descriptions tuned for گزارش برنامه صعود کوهنوردی / سنگ‌نوردی / یخ‌نوردی
- Kahar report gets `peak` front matter for structured data

### Activate once
1. Create a scheduled Automation (daily cron `0 3 * * *`) on repo `KavehRS/website`, branch `master`
2. Paste the prompt from `.cursor/automations/daily-seo-prompt.md`
3. Save and activate
4. Optional: add GitHub secret `CURSOR_API_KEY` for the Actions API fallback
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

