### PR TITLE
Note weather-based gear in Kahar draft sample

### DIFF
--- a/_drafts/samples/kahar-peak-report-framework-sample.md
+++ b/_drafts/samples/kahar-peak-report-framework-sample.md
@@ -19,8 +19,9 @@ Source snapshot of the Kahar pre-report framework.
 When creating a NEW climb report (even for Kahar again):
 - keep the SECTION FRAMEWORK
 - rewrite prose so it is not a duplicate of any published logbook entry
-- refresh weather, team, dates, route notes, and climb narrative from latest facts
+- refresh weather, gear (from date + weather), team, dates, route notes, and climb narrative from latest facts
 -->
+
 
 **گزارش برنامه صعود به قله کهار**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tiny follow-up: draft sample guidance now says to refresh gear from climb date + weather, matching the rules already merged in #23.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

