### PR TITLE
Logbook hub title گزارش صعود + SEO intro

### DIFF
--- a/logbook.md
+++ b/logbook.md
@@ -1,7 +1,9 @@
 ---
 layout: default
-title: گزارش برنامه صعود کوهنوردی، سنگ‌نوردی و یخ‌نوردی
-description: "آرشیو گزارش برنامه‌های صعود به تفکیک کمپ آموزشی، برفچال، یخچال، آبشار یخی، صعود زمستانه، کوهنوردی مرتفع، کوهپیمایی، سنگ‌نوردی و دیواره‌نوردی."
+title: گزارش صعود
+description: >-
+  آرشیو گزارش‌های واقعی صعود کوهنوردی، سنگ‌نوردی، دیواره‌نوردی و صعود زمستانه
+  در البرز؛ از مسیر و شرایط هوا تا تجهیزات، تیم و تجربهٔ اجرا.
 permalink: /logbook/
 lang: fa-IR
 dir_attr: rtl
@@ -10,12 +12,10 @@ dir_attr: rtl
 {% assign discipline_order = site.data.logbook_disciplines.order %}
 {% assign discipline_labels = site.data.logbook_disciplines.labels %}
 
-<h1>گزارش برنامه صعود</h1>
-<p>گزارش‌ها بر اساس نوع برنامه تفکیک شده‌اند: کمپ آموزشی، برفچال، یخچال، آبشار یخی، صعود زمستانه، کوهنوردی مرتفع (بالای ۴۰۰۰ متر)، کوهپیمایی، سنگ‌نوردی و دیواره‌نوردی.</p>
-
+<h1>گزارش صعود</h1>
+<p>اینجا روایت صعودهای اجراشده جمع شده است: قله‌های مرتفع، تیغه‌ها، کمپ‌های آموزشی برفچال و برنامه‌های زمستانه. هر گزارش مسیر، هوا، تجهیزات و جزئیات اجرا را برای کوهنوردانی می‌نویسد که پیش از برنامه به منبع دقیق نیاز دارند.</p>
 
 {% for disc in discipline_order %}
-  {% assign disc_posts = '' | split: '' %}
   {% assign has_posts = false %}
   {% for post in site.logbook reversed %}
     {% assign post_cats = post.categories | default: post.disciplines %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
- Visible hub title / H1 is now **گزارش صعود** (was the longer “گزارش برنامه صعود …” string)
- Replaced the discipline laundry-list paragraph with a short reader- and search-friendly intro
- Meta description updated accordingly; category-grouped sections remain below

All `_logbook` posts already have discipline `categories`; none were missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

