### PR TITLE
نمایش ساده گزارش‌های مرتبط بدون توضیح و عنوان دسته

### DIFF
--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,6 +1,6 @@
 {% comment %}
-Related logbook reports: group by shared activity disciplines (categories),
-not by template similarity or loose tag overlap.
+Related logbook reports: select by shared activity disciplines (categories),
+not by template similarity or loose tag overlap. Display is a flat list for readers.
 Manual page.related still wins when provided.
 {% endcomment %}
 {% if page.related and page.related.size > 0 %}
@@ -19,40 +19,36 @@ Manual page.related still wins when provided.
   {% endif %}
   {% if page_cats and page_cats.size > 0 %}
     {% assign discipline_order = site.data.logbook_disciplines.order %}
-    {% assign discipline_labels = site.data.logbook_disciplines.labels %}
-    {% assign related_blocks = '' %}
-    {% for disc in discipline_order %}
-      {% if page_cats contains disc %}
-        {% assign disc_count = 0 %}
-        {% assign disc_items = '' %}
-        {% for post in site.logbook reversed %}
-          {% if post.url != page.url and disc_count < 4 %}
-            {% assign post_cats = post.categories %}
-            {% if post_cats == nil or post_cats.size == 0 %}
-              {% assign post_cats = post.disciplines %}
-            {% endif %}
-            {% if post_cats contains disc %}
-              {% assign disc_count = disc_count | plus: 1 %}
-              {% capture one_item %}<li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>{% endcapture %}
-              {% assign disc_items = disc_items | append: one_item %}
-            {% endif %}
+    {% assign related_items = '' %}
+    {% assign related_count = 0 %}
+    {% assign seen_urls = '|' %}
+    {% for post in site.logbook reversed %}
+      {% if post.url != page.url and related_count < 6 %}
+        {% assign post_cats = post.categories %}
+        {% if post_cats == nil or post_cats.size == 0 %}
+          {% assign post_cats = post.disciplines %}
+        {% endif %}
+        {% assign shares_discipline = false %}
+        {% for disc in discipline_order %}
+          {% if page_cats contains disc and post_cats contains disc %}
+            {% assign shares_discipline = true %}
           {% endif %}
         {% endfor %}
-        {% if disc_count > 0 %}
-          {% capture one_block %}
-  <h3 style="font-size: 1rem; margin: 1rem 0 0.5rem;">{{ discipline_labels[disc] }}</h3>
-  <ul>{{ disc_items }}</ul>
-          {% endcapture %}
-          {% assign related_blocks = related_blocks | append: one_block %}
-        {% endif %}
+        {% assign url_token = post.url | append: '|' %}
+        {% unless seen_urls contains url_token %}
+          {% if shares_discipline %}
+            {% assign related_count = related_count | plus: 1 %}
+            {% assign seen_urls = seen_urls | append: url_token %}
+            {% capture one_item %}<li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>{% endcapture %}
+            {% assign related_items = related_items | append: one_item %}
+          {% endif %}
+        {% endunless %}
       {% endif %}
     {% endfor %}
-    {% assign related_blocks = related_blocks | strip %}
-    {% if related_blocks != '' %}
-<nav class="related-posts" aria-label="گزارش‌های مرتبط بر اساس نوع برنامه" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
-  <h2 style="font-size: 1.1rem; margin-bottom: 0.5rem;">گزارش‌های مرتبط</h2>
-  <p style="margin: 0 0 0.75rem; color: #555; font-size: 0.9rem;">بر اساس نوع برنامه (نه شباهت ظاهر گزارش)</p>
-  {{ related_blocks }}
+    {% if related_count > 0 %}
+<nav class="related-posts" aria-label="گزارش‌های مرتبط" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
+  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">گزارش‌های مرتبط :</h2>
+  <ul>{{ related_items }}</ul>
 </nav>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## خلاصه
متن «بر اساس نوع برنامه...» و عنوان‌های دسته (مثل کوهنوردی مرتفع) برای راهنمای اجرای ایجنت بود و نباید به خواننده نشان داده شود.

## تغییر
در `_includes/related-links.html`:
- انتخاب مرتبط‌ها همچنان بر اساس دسته‌های مشترک است
- نمایش عمومی فقط عنوان **گزارش‌های مرتبط :** و فهرست تخت لینک‌هاست

## تست
- `bundle exec jekyll build`
- خروجی صفحه کهار دقیقاً همان فهرست تخت موردنظر کاربر است
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

