### PR TITLE
همگام‌سازی رول‌ها/سمپل‌ها و حذف توضیحات ایجنت از صفحات

### DIFF
--- a/.cursor/automations/daily-seo-prompt.md
+++ b/.cursor/automations/daily-seo-prompt.md
@@ -32,5 +32,7 @@ Then audit the live site + repo, implement only evidence-based SEO improvements 
 If you make verified high-confidence changes: open a PR on a cursor/*-33ce branch and merge to master after a clean build.
 If nothing material needs changing: do not open a PR; leave a brief summary of what you checked.
 
-Never invent climb facts, never duplicate report prose for the same peak, never keyword-stuff, never commit secrets.
+Preserve logbook UI rules from logbook-reports.mdc: hub chronological; related links = flat «گزارش‌های مرتبط :» only (no agent blurbs / category subheads on pages).
+
+Never invent climb facts, never duplicate report prose for the same peak, never keyword-stuff, never commit secrets, never publish agent notes into live HTML.
 ```

--- a/.cursor/rules/logbook-reports.mdc
+++ b/.cursor/rules/logbook-reports.mdc
@@ -14,7 +14,8 @@ When the user asks for a new climb / ascent report (`گزارش صعود`), or w
 3. `categories` from `_data/logbook_disciplines.yml` only (see table below) — never vague `mountaineering` / `logbook`.
 4. Section order: peak specs → region → **weather (3 sources)** → flora/fauna → access → routes → shelter/water → season → views → **چالش‌های برنامه** → **gear (date+weather)** → team → narrative (per program day if multi-day).
 5. Images: `assets/mount/logbook/<exact-url-slug>/` matching the report URL (see `.cursor/rules/logbook-assets.mdc`).
-6. Related links: automatic by shared categories — not template look-alikes.
+6. Related links: **select** by shared categories — not template look-alikes. **Public UI** must stay a flat list only (see below). Never put agent/implementation notes in published HTML.
+7. Program length/dates: use exactly what the user states (one-day vs multi-day). Do not invent overnight stays. Example: Kahar ۱۴۰۵/۰۵/۱۶ is **one-day** — see sample; do not reintroduce a two-day Kahar plan unless the user asks.
 
 ## Categories (required)
 
@@ -31,11 +32,30 @@ When the user asks for a new climb / ascent report (`گزارش صعود`), or w
 | `rock-climbing` | سنگ‌نوردی |
 | `wall-climbing` | دیواره‌نوردی |
 
-Use every slug that truly applies. Related posts group by these.  
-`/logbook/` lists reports **chronologically by date** (newest first), not grouped by category.
+Use every slug that truly applies.
+
+### Hub `/logbook/`
+
+Lists reports **chronologically by date** (newest first). **Do not** group the hub by category.
+
+### Related links (reader UI)
+
+Implementation: `_includes/related-links.html` selects matches by shared `categories`.  
+**Visible to readers — only this shape:**
+
+- Heading: `گزارش‌های مرتبط :`
+- Flat bullet list of report titles/links
+
+**Do not show** on any public page:
+
+- Agent explanations such as «بر اساس نوع برنامه (نه شباهت ظاهر گزارش)»
+- Discipline/category subheadings (e.g. «کوهنوردی مرتفع…», «کوهنوردی فنی»)
+- Any other implementation notes meant for agents
+
+Those notes belong only in `.cursor/`, `_drafts/` HTML comments / USAGE blocks — never in live page copy.
 
 Classification notes:
-- تیغه / ژاندارم / دست‌به‌سنگ آلپی → `technical-mountaineering` (کوهنوردی فنی)
+- تیغه / ژاندارم / دست‌به‌سنگ آلپی → `technical-mountaineering` (کوهنوردی فنی) — **not** سنگ‌نوردی / دیواره‌نوردی
 - `rock-climbing` / `wall-climbing` فقط برای سنگ‌نوردی یا دیواره‌نوردی واقعی
 
 

--- a/.cursor/rules/seo-daily-agent.mdc
+++ b/.cursor/rules/seo-daily-agent.mdc
@@ -34,9 +34,12 @@ Goal: make https://www.kavehrs.com the leading Persian source for mountaineering
 When touching `_logbook` content while doing SEO work:
 - keep the required triple-source weather block (Open-Meteo + Mountain-Forecast + Meteoblue)
 - keep gear aligned to date/forecast
-- keep `categories` on the discipline taxonomy in `_data/logbook_disciplines.yml` (including `winter-ascent` / صعود زمستانه)
+- keep `categories` on the discipline taxonomy in `_data/logbook_disciplines.yml` (including `technical-mountaineering` / کوهنوردی فنی and `winter-ascent` / صعود زمستانه)
+- ridge/gendarme/alpine hand-and-foot → `technical-mountaineering`; rock/wall only for true rock/wall
 - keep images under `assets/mount/logbook/<exact-url-slug>/`
 - if touching weather numbers that changed noticeably, keep `## چالش‌های برنامه` in sync
+- hub `/logbook/` stays chronological; related UI stays flat `گزارش‌های مرتبط :` (no agent blurbs / category subheads)
+- never publish agent/implementation notes into live page copy
 per `.cursor/rules/logbook-reports.mdc` and `.cursor/rules/logbook-assets.mdc`. Do not invent vague categories.
 
 

--- a/.cursor/skills/daily-seo-audit/SKILL.md
+++ b/.cursor/skills/daily-seo-audit/SKILL.md
@@ -12,8 +12,10 @@ Run this every 24 hours (Cursor Automation or GitHub Action → Cloud Agent API)
 Improve discoverability of Persian **گزارش برنامه صعود** content for the disciplines in `_data/logbook_disciplines.yml`:
 
 - کمپ‌های آموزشی · برفچال · یخچال · آبشار یخی · صعود زمستانه
-- کوهنوردی مرتفع (بالای ۴۰۰۰ متر) · کوهپیمایی · سنگ‌نوردی · دیواره‌نوردی
+- کوهنوردی مرتفع (بالای ۴۰۰۰ متر) · کوهنوردی فنی · کوهپیمایی · سنگ‌نوردی · دیواره‌نوردی
 - plus یخ‌نوردی / DryTooling where relevant in report content
+
+Hub `/logbook/` is chronological. Related blocks must stay a flat `گزارش‌های مرتبط :` list (no agent blurbs / category subheads on the page).
 
 Primary hub: `/logbook/` · Site: `https://www.kavehrs.com`
 

--- a/.cursor/skills/logbook-ascent-report/SKILL.md
+++ b/.cursor/skills/logbook-ascent-report/SKILL.md
@@ -20,13 +20,16 @@ Use `_drafts/samples/kahar-peak-report-framework-sample.md` only as structure �
 ## Deliverables for a new report
 
 1. `_logbook/YYYY-MM-DD-<slug>.md` with SEO + `peak` front matter when known
-2. `categories` from `_data/logbook_disciplines.yml` (ridge/gendarme/alpine hand-and-foot → `technical-mountaineering`; use `rock-climbing` / `wall-climbing` only for true rock/wall routes)
-
+2. `categories` from `_data/logbook_disciplines.yml`:
+   - ridge / gendarme / alpine hand-and-foot → `technical-mountaineering` (کوهنوردی فنی)
+   - `rock-climbing` / `wall-climbing` only for true rock or multipitch wall routes
 3. Triple weather for every program day (Open-Meteo, Mountain-Forecast, Meteoblue)
 4. `## چالش‌های برنامه` — include weather volatility when forecasts differ or swing noticeably
 5. Gear derived from date(s) + that forecast (and “not needed for this date”)
 6. `assets/mount/logbook/<exact-url-slug>/` for all images
-7. Multi-day narrative outline when the program is more than one day
+7. Narrative outline matching the real program length (one-day vs multi-day). Do not invent overnight stays. Kahar sample is one-day on ۱۶ مرداد ۱۴۰۵ — do not turn it into a two-day plan unless the user asks.
+8. Hub `/logbook/` stays chronological by date (not category sections). Related links: select by shared categories; reader UI = only `گزارش‌های مرتبط :` + flat list (no agent explanation, no discipline headings).
+9. Never publish agent notes (implementation reminders, «بر اساس نوع برنامه…», path references to `.cursor/`) in live page HTML.
 
 ## Scheduled weather runs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,14 @@ If a forecast change is **noticeable**, add/update `## چالش‌های برن�
 Folder `assets/mount/logbook/<slug>/` must match the report URL slug exactly (`/logbook/<slug>/`). See `.cursor/rules/logbook-assets.mdc`.
 
 
-Logbook `categories` must use the discipline slugs in `_data/logbook_disciplines.yml` (training camp, snowfield, glacier, icefall, winter ascent / صعود زمستانه, high-altitude, technical mountaineering / کوهنوردی فنی, hiking, rock-climbing, wall-climbing). Related reports are grouped by those categories.
+## Logbook categories, hub, related links
+
+- `categories` must use discipline slugs in `_data/logbook_disciplines.yml` only (training-camp, snowfield, glacier, icefall, winter-ascent, high-altitude, technical-mountaineering / کوهنوردی فنی, hiking, rock-climbing, wall-climbing).
+- Classification: ridge / gendarme / alpine hand-and-foot → `technical-mountaineering`. Use `rock-climbing` / `wall-climbing` only for true rock or multipitch wall routes.
+- Hub `/logbook/` lists reports **chronologically by date** (newest first), not by category.
+- Related reports are **selected** by shared categories, but the **public UI** is only `گزارش‌های مرتبط :` + a flat list — no «بر اساس نوع برنامه…» note and no category subheadings on the page.
+- Never put agent/implementation instructions into published page copy; keep them in `.cursor/` and `_drafts/` comments.
+- Program dates/length come from the user only (e.g. Kahar is one-day on ۱۶ مرداد ۱۴۰۵ unless the user changes it).
 
 
 ## Daily SEO agent

--- a/_data/logbook_disciplines.yml
+++ b/_data/logbook_disciplines.yml
@@ -1,5 +1,7 @@
 # Activity disciplines for logbook reports (categories).
-# Related reports group by these — not by template/tag similarity.
+# Related reports are SELECTED by shared slugs — not by template/tag similarity.
+# Public related UI is a flat list under «گزارش‌های مرتبط :» (no category headings, no agent notes).
+# Hub /logbook/ is chronological by date, not grouped by these labels.
 # Keep this file as the single source of truth; rules/templates/samples must match it.
 #
 # Use rock-climbing / wall-climbing only for true sport/trad rock or multipitch wall routes.

--- a/_drafts/logbook-ascent-report-template.md
+++ b/_drafts/logbook-ascent-report-template.md
@@ -12,22 +12,29 @@ dir_attr: rtl
 ---
 
 <!--
-USAGE
+USAGE (agent-only — do not copy this comment block into published pages)
 1) Copy structure into `_logbook/YYYY-MM-DD-<peak-slug>.md`
 2) Front matter must include: lang, dir_attr, description, date, tags, image,
    categories from _data/logbook_disciplines.yml
    (training-camp | snowfield | glacier | icefall | winter-ascent | high-altitude | technical-mountaineering | hiking | rock-climbing | wall-climbing),
    and peak: { name, elevation_m, latitude, longitude, region } when known (SEO JSON-LD)
-3) Fill facts for THIS climb only
-4) Weather MUST cover every program day from three sources: Open-Meteo + mountain-forecast.com + meteoblue.com
+3) Classification: ridge/gendarme/alpine hand-and-foot → technical-mountaineering (کوهنوردی فنی).
+   rock-climbing / wall-climbing only for true rock or multipitch wall — never for alpine ridge trips.
+4) Fill facts for THIS climb only. Program length/dates = exactly what the user said (one-day vs multi-day).
+   Do not invent overnight stays. Kahar sample is one-day on ۱۶ مرداد ۱۴۰۵.
+5) Weather MUST cover every program day from three sources: Open-Meteo + mountain-forecast.com + meteoblue.com
    (if Mountain-Forecast lacks the peak, use nearest elevation-matched proxy and say so)
-5) Weather is refreshed at 04:00 / 10:00 / 16:00 / 22:00 Asia/Tehran from creation until 22:00 the night before the climb
-6) If a forecast change is noticeable, add/update ## چالش‌های برنامه with before→after details (sources, time, impact)
-7) Gear list MUST be derived from climb date(s) + that triple weather forecast (not a generic seasonal packing list)
-8) Images live in assets/mount/logbook/<exact-url-slug>/ matching the report URL slug
-9) Related reports are auto-grouped by categories — do not rely on template look-alike links
-10) Before publish: compare against existing `_logbook/*` for the same peak
-11) Never paste this sample prose unchanged into a published report
+6) Weather is refreshed at 04:00 / 10:00 / 16:00 / 22:00 Asia/Tehran from creation until 22:00 the night before the climb
+7) If a forecast change is noticeable, add/update ## چالش‌های برنامه with before→after details (sources, time, impact).
+   Thresholds live in .cursor/rules/logbook-reports.mdc — never paste that path into the published report body.
+8) Gear list MUST be derived from climb date(s) + that triple weather forecast (not a generic seasonal packing list)
+9) Images live in assets/mount/logbook/<exact-url-slug>/ matching the report URL slug
+10) Related reports: SELECT by shared categories in _includes/related-links.html.
+    Public UI must be only «گزارش‌های مرتبط :» + flat list — no «بر اساس نوع برنامه…», no category headings.
+11) Hub /logbook/ is chronological by date (newest first), not grouped by category.
+12) Before publish: compare against existing `_logbook/*` for the same peak
+13) Never paste this template prose unchanged into a published report
+14) Never publish agent/implementation notes on live pages
 -->
 
 
@@ -37,7 +44,7 @@ Example front matter categories:
 categories: [high-altitude]
 # or: [training-camp, snowfield]
 # or: [winter-ascent, hiking]
-# or: [technical-mountaineering]
+# or: [technical-mountaineering]  # ridge / gendarme / alpine hand-and-foot
 # or: [rock-climbing]  # only true rock climbing
 # or: [wall-climbing]  # only true multipitch/wall
 -->
@@ -160,8 +167,6 @@ categories: [high-altitude]
 - **منبع(ها):** Open-Meteo / Mountain-Forecast / Meteoblue
 - **قبل → بعد:** {{اعداد مشخص: دما، باد/تندباد، احتمال/مقدار بارش، سطح انجماد}}
 - **اثر روی برنامه:** {{زمان‌بندی / مسیر / شب‌مانی / تجهیزات / تصمیم اجرا}}
-
-> آستانه‌های «قابل‌ملاحظه» در `.cursor/rules/logbook-reports.mdc` — در به‌روزرسانی‌های زمان‌بندی‌شده اگر تغییر مهم بود، این بخش را پر کن؛ فقط عوض کردن اعداد هوا کافی نیست.
 
 ### سایر چالش‌ها
 

--- a/_drafts/samples/kahar-peak-report-framework-sample.md
+++ b/_drafts/samples/kahar-peak-report-framework-sample.md
@@ -15,19 +15,24 @@ categories: [high-altitude]
 
 
 <!--
-SAMPLE / DRAFT ONLY
-Source snapshot of the Kahar pre-report framework.
+SAMPLE / DRAFT ONLY (agent guidance — never copy this comment into published pages)
+Source snapshot of the Kahar pre-report framework (one-day program on ۱۶ مرداد ۱۴۰۵ / 2026-08-07).
 When creating a NEW climb report (even for Kahar again):
-- keep the SECTION FRAMEWORK
-- rewrite prose so it is not a duplicate of any published logbook entry
+- keep the SECTION FRAMEWORK; rewrite prose so it is not a duplicate of any published logbook entry
 - follow master checklist in .cursor/rules/logbook-reports.mdc
+- THIS Kahar program is one-day on 1405/05/16 — do not reintroduce a two-day overnight plan unless the user asks
+- program length/dates always come from the user; do not invent overnight stays
 - refresh weather (every program day, 3 sources) on 04:00/10:00/16:00/22:00 Asia/Tehran until 22:00 night before climb
 - if forecast change is noticeable: add/update ## چالش‌های برنامه with before→after details
 - gear from date + weather; categories from _data/logbook_disciplines.yml
   (training-camp, snowfield, glacier, icefall, winter-ascent, high-altitude, technical-mountaineering, hiking, rock-climbing, wall-climbing)
+- ridge/gendarme/alpine hand-and-foot → technical-mountaineering; rock-climbing/wall-climbing only for true rock/wall
 - images in assets/mount/logbook/<exact-url-slug>/ matching the report URL
-- related links / hub group by categories, not template similarity
+- related links: SELECT by shared categories; public UI = «گزارش‌های مرتبط :» + flat list only
+  (no «بر اساس نوع برنامه…», no discipline headings on the page)
+- hub /logbook/ is chronological by date, not grouped by category
 - never republish this sample prose for a new report
+- never publish agent/implementation notes on live pages
 -->
 
 

--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,6 +1,8 @@
 {% comment %}
-Related logbook reports: select by shared activity disciplines (categories),
-not by template similarity or loose tag overlap. Display is a flat list for readers.
+Related logbook reports: SELECT by shared activity disciplines (categories),
+not by template similarity or loose tag overlap.
+Reader UI must stay: heading «گزارش‌های مرتبط :» + flat list only.
+Do NOT render agent notes or discipline/category subheadings.
 Manual page.related still wins when provided.
 {% endcomment %}
 {% if page.related and page.related.size > 0 %}

--- a/_seo/daily-log.md
+++ b/_seo/daily-log.md
@@ -6,6 +6,14 @@ Append-only run notes for the scheduled SEO agent. Not published on the site.
 
 - Added daily SEO skill, Cursor Automation prompt, optional GitHub Actions trigger.
 - Baseline: logbook CollectionPage + Mountain Article JSON-LD when `page.peak` is set.
-- Auto related links for logbook by shared tags.
+- Auto related links for logbook by shared discipline categories (public UI: flat «گزارش‌های مرتبط :» list).
 - Tuned site/logbook descriptions toward گزارش برنامه صعود کوهنوردی / سنگ‌نوردی / یخ‌نوردی.
 - Sources consulted at bootstrap: Google Search Central (SEO basics, sitemaps, structured data), schema.org `Article` / `Mountain` / `CollectionPage`, Bing Webmaster Guidelines overview.
+
+## 2026-08-04 — related UI + taxonomy sync
+
+- Related public UI: only «گزارش‌های مرتبط :» + flat list (no «بر اساس نوع برنامه…», no discipline headings).
+- Hub `/logbook/` chronological by date.
+- Added/confirmed `technical-mountaineering` (کوهنوردی فنی) for ridge/gendarme/alpine hand-and-foot; rock/wall reserved for true rock/wall.
+- Kahar pre-report corrected to one-day on ۱۶ مرداد ۱۴۰۵.
+- Synced AGENTS.md, logbook rules/skills/template/sample.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## خلاصه
- تأیید شد که در خروجی سایت هیچ متن ایجنتی مثل «بر اساس نوع برنامه…» یا عنوان دسته در بخش مرتبط‌ها نیست؛ فقط `گزارش‌های مرتبط :` + فهرست تخت.
- همهٔ تصمیم‌های قبلی ساخت گزارش صعود در رول‌ها، اسکیل‌ها، قالب، سمپل کهار، `AGENTS.md` و taxonomy ثبت شد.

## موارد ثبت‌شده در docs
- هاب `/logbook/` فقط ترتیب زمانی
- Related: انتخاب با دسته، نمایش عمومی تخت بدون توضیح/عنوان دسته
- تیغه/ژاندارم/آلپی → `technical-mountaineering`؛ سنگ/دیواره فقط مسیر واقعی
- کهار یک‌روزهٔ ۱۶ مرداد ۱۴۰۵؛ طول برنامه فقط از گفتهٔ کاربر
- ممنوعیت انتشار یادداشت‌های ایجنت در HTML عمومی

## تست
- `bundle exec jekyll build`
- اسکن `_site/**/*.html` برای متن‌های ایجنتی: بدون نتیجه
- نمونه‌های کهار/دارآباد/جانستون: related UI تخت
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afea95d2-f882-4324-af31-756babc133ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afea95d2-f882-4324-af31-756babc133ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

