### PR TITLE
docs: Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,12 @@ Become the authoritative Persian source for:
 - Publish `_drafts/`
 - Invent climb facts, weather, or team members
 - Weaken uniqueness of logbook narratives for SEO
+
+## Cursor Cloud specific instructions
+
+Static Jekyll 4 site (Ruby 3.2). Standard commands live in `## Install / verify` above.
+
+- Gems install into `./vendor/bundle` (gitignored via a local `bundle config path`). The startup update script runs `bundle install`, so gems are ready — no need to reinstall unless `Gemfile`/`Gemfile.lock` changed.
+- Run the dev server with `bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload`. It auto-regenerates on file changes; there is no separate lint step for this site — `bundle exec jekyll build` succeeding is the check.
+- The Sass `@import` / `lighten()` deprecation warnings during build/serve are expected and harmless; the build still finishes with exit code 0.
+- Adding/removing content files is picked up by the running server via auto-regeneration; editing `_config.yml` requires restarting the server.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the local development environment for this Jekyll site (kavehrs.com), and adds durable startup guidance for future Cursor Cloud agents.

## What was done

- Installed the toolchain: Ruby 3.2.3 + build tools (system deps, baked into the VM snapshot), Bundler `4.0.12` (matching `Gemfile.lock`'s `BUNDLED WITH`), and all 40 Jekyll gems into a gitignored `vendor/bundle`.
- Verified the build (`bundle exec jekyll build`) succeeds and that `_drafts/` and `.cursor/` are excluded from `_site/`.
- Ran the dev server (`bundle exec jekyll serve --livereload`) and browsed the homepage, logbook hub, an individual climb report, and confirmed live auto-regeneration with a temporary test page (removed, not committed).

## Changes in this PR

- `AGENTS.md`: new `## Cursor Cloud specific instructions` section with non-obvious startup notes (gem path, dev server command, harmless Sass deprecation warnings, `_config.yml` requires restart).

The startup update script (`bundle config set --local path vendor/bundle` + `bundle install`) is registered separately via the environment setup tool; no code changes were needed beyond these docs.

## Verification

[jekyll_dev_site_walkthrough.mp4](https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_dev_site_walkthrough.mp4)

[Homepage](https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Logbook hub](https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogbook_hub.webp)
[Kholeno Peak report](https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkholeno_report.webp)
[Live-regeneration test page](https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_cloud_test.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cbcf624-5ed5-4cdf-8519-d275a82e8e64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

