### PR TITLE
صفحهٔ اول: چهار مطلب تازه از گزارش صعود و یادداشت‌ها

### DIFF
--- a/.cursor/rules/blog-posts.mdc
+++ b/.cursor/rules/blog-posts.mdc
@@ -66,6 +66,7 @@ Write as the author (من). No agent notes, no JSON-LD talk, no «این بند 
 - Fill `related` from real sibling posts (same series or shared tags)
 - Public UI: heading `یادداشت‌های مرتبط :` + flat list (`_includes/related-links.html`)
 - Hub `/blog/` is chronological (newest first)
+- Homepage `/` is filled automatically from the 4 newest blog notes and 4 newest logbook reports (`_includes/home-latest.html`). Do not edit `index.md` teasers.
 
 ## Facts
 

--- a/.cursor/rules/logbook-reports.mdc
+++ b/.cursor/rules/logbook-reports.mdc
@@ -17,6 +17,7 @@ When the user asks for a new climb / ascent report (`گزارش صعود`), or w
 6. Related links: **select** by shared categories — not template look-alikes. **Public UI** must stay a flat list only (see below). Never put agent/implementation notes in published HTML. Body copy is the climber’s voice (من / ما / تیم) — no unpublished-GPS asides, JSON-LD, or source-name footnotes.
 7. Program length/dates: use exactly what the user states (one-day vs multi-day). Do not invent overnight stays. Example: Kahar ۱۴۰۵/۰۵/۱۶ is **one-day** — see sample; do not reintroduce a two-day Kahar plan unless the user asks.
 8. **Visible dates on the site are Jalali** for readers (footer «آخرین بروزرسانی», post meta, `/logbook/` list) via `_includes/jalali-date.html` → e.g. `13 مرداد 1405`. Keep machine `datetime=` / front-matter `date:` in Gregorian. In report **body** prose, prefer Jalali for program dates (optionally add Gregorian in parentheses when useful, e.g. weather stamps).
+9. Homepage `/` lists the 4 newest reports automatically (`_includes/home-latest.html`). Do not hardcode teasers in `index.md`.
 
 ## Categories (required)
 

--- a/.cursor/skills/blog-post/SKILL.md
+++ b/.cursor/skills/blog-post/SKILL.md
@@ -27,7 +27,9 @@ Automation prompt: `.cursor/automations/blog-post-prompt.md`
 5. Images in `assets/blog/YYYY-MM-DD-<slug>/` matching the URL path (`.gitkeep` if photos come later)
 6. Body from the template sections — rewrite all prose; never ship placeholders like `{{عنوان}}`
 7. Hub `/blog/` stays chronological; related UI = `یادداشت‌های مرتبط :` + flat list
-8. `bundle exec jekyll build` must succeed; `_drafts/` must not appear in `_site/`
+8. Homepage `/` always lists the **4 newest** `_blog/` and `_logbook/` items via `_includes/home-latest.html` — do **not** hardcode teasers in `index.md`
+9. If `image:` is set, the post layout shows it at the top of the note (and as OG cover)
+10. `bundle exec jekyll build` must succeed; `_drafts/` must not appear in `_site/`
 
 ## Voice and facts
 

--- a/.cursor/skills/logbook-ascent-report/SKILL.md
+++ b/.cursor/skills/logbook-ascent-report/SKILL.md
@@ -43,8 +43,9 @@ Use `_drafts/samples/kahar-peak-report-framework-sample.md` only as structure �
 6. `assets/mount/logbook/<exact-url-slug>/` for all images
 7. Narrative outline → post-climb completion when user provides details. Program length from user only (Kahar = one-day ۱۶ مرداد ۱۴۰۵ unless changed).
 8. Hub `/logbook/` chronological; related UI = only `گزارش‌های مرتبط :` + flat list
-9. Never publish agent notes in live HTML
-10. Reader-facing UI dates Jalali (`_includes/jalali-date.html`)
+9. Homepage `/` always lists the 4 newest reports via `_includes/home-latest.html` (do not hardcode teasers in `index.md`)
+10. Never publish agent notes in live HTML
+11. Reader-facing UI dates Jalali (`_includes/jalali-date.html`)
 
 ## Scheduled weather runs (automatic when billing enabled)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,9 @@ When asked for a `پست جدید وبلاگ` / یادداشت فنی / update t
 4. File: `_blog/YYYY-MM-DD-<slug>.md` with zero-padded date, `lang: fa-IR`, YAML `tags` array, unique description.
 5. Images for new notes: `assets/blog/<exact-url-slug>/`; comment `image:` out until files exist.
 6. Related UI stays `یادداشت‌های مرتبط :` + flat list. Hub `/blog/` chronological.
-7. For a Cursor Automation, paste `.cursor/automations/blog-post-prompt.md` at https://cursor.com/automations/new
-8. Open a PR on `cursor/<descriptive-name>-33ce`, verify `bundle exec jekyll build`.
+7. Homepage `/` lists the 4 newest notes and reports automatically; do not hardcode teasers in `index.md`.
+8. For a Cursor Automation, paste `.cursor/automations/blog-post-prompt.md` at https://cursor.com/automations/new
+9. Open a PR on `cursor/<descriptive-name>-33ce`, verify `bundle exec jekyll build`.
 
 ## Instagram → blog agent
 

--- a/_includes/home-latest.html
+++ b/_includes/home-latest.html
@@ -1,0 +1,24 @@
+{% comment %}
+Homepage teasers: four newest logbook reports and four newest blog notes.
+Do not hardcode titles in index.md — this include is the source of truth.
+{% endcomment %}
+{% assign latest_logbook = site.logbook | sort: 'date' | reverse %}
+{% assign latest_blog = site.blog | sort: 'date' | reverse %}
+<div class="home-columns">
+  <div class="home-column">
+    <h2><a href="{{ '/logbook/' | relative_url }}">گزارش صعود</a></h2>
+    <ul>
+      {% for post in latest_logbook limit: 4 %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="home-column">
+    <h2><a href="{{ '/blog/' | relative_url }}">یادداشت‌ها</a></h2>
+    <ul>
+      {% for post in latest_blog limit: 4 %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -3,7 +3,6 @@ layout: default
 ---
 
 {% assign dir = page.dir_attr | default: 'ltr' %}
-{% assign about_parts = content | split: '<!--home-columns-->' %}
 
 <div class="about-page" dir="{{ dir }}">
   <div class="about-hero">
@@ -19,10 +18,10 @@ layout: default
     {% endif %}
 
     <div class="about-intro">
-      {{ about_parts[0] }}
+      {{ content }}
     </div>
   </div>
-  {% if about_parts.size > 1 %}
-    {{ about_parts[1] }}
+  {% if page.url == '/' %}
+    {% include home-latest.html %}
   {% endif %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,6 +17,10 @@ layout: default
 <p class="meta"><time datetime="{{ page.date | date_to_xmlschema }}"><small>{% include jalali-date.html date=page.date %}</small></time></p>
 {% endif %}
 <p class="meta"><small>نویسنده: <a href="{{ '/' | relative_url }}">کاوه‌ رضائی‌شیراز</a></small></p>
+{% assign default_img = site.logo | default: '/assets/images/logos/1/kavehrs.jpg' %}
+{% if page.image and page.image != empty and page.image != default_img %}
+<img class="post-cover" src="{{ page.image | relative_url }}" alt="{{ page.title | escape }}">
+{% endif %}
 
 {{ content }}
 

--- a/assets/css/_sass/profile.scss
+++ b/assets/css/_sass/profile.scss
@@ -79,6 +79,24 @@
   margin: 0 0 0.5rem;
 }
 
+.home-column h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-column h2 a:hover {
+  color: $brand-color;
+}
+
+.post-cover {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  margin: 0.85rem 0 1.25rem;
+  border-radius: 2px;
+}
+
 .home-column p {
   margin: 0 0 0.75rem;
   font-size: 0.95rem;

--- a/index.md
+++ b/index.md
@@ -22,27 +22,3 @@ lang: fa-IR
     <li>زادهٔ مهر ۱۳۶۴ در گیلان | ساکن تهران</li>
   </ul>
 </blockquote>
-
-<!--home-columns-->
-<div class="home-columns">
-<div class="home-column" markdown="1">
-
-## گزارش صعود
-
-- [صعود به قله کهار](/logbook/2026-08-07-kahar-peak/) — ۱۶ مرداد ۱۴۰۵، از کلوان
-- [کمپ برفچال لشگرک (حصارچال)](/logbook/2026-07-01-TrainingCampforSnowNavigationTechniques-lashgarak/)
-- [صعود قله خلنو از تیغه‌های ژاندارم](/logbook/2024-06-20-khalno-gendarme/)
-- [یخ‌نوردی آبشار شماره ۵ روستای خور](/logbook/2023-01-05-ice-climbing-khor-5/)
-
-</div>
-<div class="home-column" markdown="1">
-
-## یادداشت‌ها
-
-- [نصب و تنظیم زبیکس ۵ — Agent لینوکس](/blog/2021-03-20-zabbix-5-agent/)
-- [نصب و تنظیم زبیکس ۵ — سرور](/blog/2021-03-18-zabbix-5-server/)
-- [راه‌های ساده برای داشتن کد تمیز](/blog/2020-9-16-Clean-Code/)
-- [مفاهیم اولیه برنامه‌نویسی ۱: مفاهیم پایه](/blog/2020-8-31-basic-overview-of-programming-part1/)
-
-</div>
-</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
صفحهٔ اول قبلاً چهار لینک ثابت در `index.md` داشت؛ برای همین یادداشت تازه («کوهنوردی، یک رفت و برگشت…») روی خانه دیده نمی‌شد تا کسی آن فهرست را دستی عوض کند.

حالا `_includes/home-latest.html` در هر بیلد چهار گزارش صعود و چهار یادداشت تازه را از کالکشن‌ها می‌کشد. عنوان ستون‌ها به `/logbook/` و `/blog/` لینک می‌مانند. `index.md` فقط دربارهٔ من است.

اگر یادداشت `image` داشته باشد و آن تصویر لوگو نباشد، همان عکس بالای متن هم نشان داده می‌شود (پوشش + داخل پست).

`bundle exec jekyll build` بدون خطا تمام شد.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15004a70-f5b2-401a-b25e-d92b8f563c9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15004a70-f5b2-401a-b25e-d92b8f563c9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

