### PR TITLE
WebMCP: ابزارهای فهرست گزارش و یادداشت + عکس کاور پست دماوند

### DIFF
--- a/_blog/2026-08-18-mountaineering-return-knowledge.md
+++ b/_blog/2026-08-18-mountaineering-return-knowledge.md
@@ -6,7 +6,7 @@ dir_attr: rtl
 description: "درددل ثبت‌شده از شب ارائه در باشگاه دماوند؛ چرا از کوهنوردی فاصله گرفتم، چه دانشی از مدیریت باشگاه گرفتم، و چرا با تمرین دوباره برگشتم."
 date: 2026-08-18
 tags: [کوهنوردی, باشگاه, مدیریت, یخ‌نوردی]
-# image: /assets/blog/2026-08-18-mountaineering-return-knowledge/cover.jpg
+image: /assets/blog/2026-08-18-mountaineering-return-knowledge/Cover.jpg
 ---
 
 🥶😋🥰

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -64,6 +64,7 @@ layout: compress
     </footer>
 
     {% include analytics.html %}
+    <script src="{{ '/assets/js/webmcp.js' | relative_url }}" defer></script>
 </body>
 
 </html>

--- a/_pages/webmcp-catalog.json
+++ b/_pages/webmcp-catalog.json
@@ -1,0 +1,30 @@
+---
+layout: null
+permalink: /webmcp-catalog.json
+sitemap: false
+---
+{
+  "site": {{ "/" | absolute_url | jsonify }},
+  "logbook": [
+    {%- assign items = site.logbook | sort: "date" | reverse -%}
+    {%- for post in items %}
+    {
+      "title": {{ post.title | jsonify }},
+      "url": {{ post.url | jsonify }},
+      "date": {{ post.date | date: "%Y-%m-%d" | jsonify }},
+      "description": {{ post.description | default: "" | jsonify }}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor %}
+  ],
+  "blog": [
+    {%- assign items = site.blog | sort: "date" | reverse -%}
+    {%- for post in items %}
+    {
+      "title": {{ post.title | jsonify }},
+      "url": {{ post.url | jsonify }},
+      "date": {{ post.date | date: "%Y-%m-%d" | jsonify }},
+      "description": {{ post.description | default: "" | jsonify }}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor %}
+  ]
+}

--- a/assets/js/webmcp.js
+++ b/assets/js/webmcp.js
@@ -1,0 +1,132 @@
+(function () {
+  'use strict';
+
+  function modelContext() {
+    if (document.modelContext && typeof document.modelContext.registerTool === 'function') {
+      return document.modelContext;
+    }
+    if (navigator.modelContext && typeof navigator.modelContext.registerTool === 'function') {
+      return navigator.modelContext;
+    }
+    return null;
+  }
+
+  function filterItems(items, query) {
+    if (!query) return items;
+    var q = String(query).toLowerCase();
+    return items.filter(function (item) {
+      var title = (item.title || '').toLowerCase();
+      var description = (item.description || '').toLowerCase();
+      return title.indexOf(q) !== -1 || description.indexOf(q) !== -1;
+    });
+  }
+
+  function allowedPath(path, catalog) {
+    if (!path || typeof path !== 'string' || path.charAt(0) !== '/') return false;
+    if (path.indexOf('//') !== -1 || path.indexOf('\\') !== -1) return false;
+    if (path === '/' || path === '/logbook/' || path === '/blog/') return true;
+    var lists = (catalog.logbook || []).concat(catalog.blog || []);
+    for (var i = 0; i < lists.length; i++) {
+      if (lists[i].url === path) return true;
+    }
+    return false;
+  }
+
+  function currentPage() {
+    return {
+      url: location.pathname,
+      title: document.title,
+      kind:
+        location.pathname.indexOf('/logbook/') === 0
+          ? 'ascent_report'
+          : location.pathname.indexOf('/blog/') === 0
+            ? 'note'
+            : location.pathname === '/'
+              ? 'home'
+              : 'page'
+    };
+  }
+
+  async function register(catalog) {
+    var ctx = modelContext();
+    if (!ctx) return;
+
+    await ctx.registerTool({
+      name: 'list_ascent_reports',
+      description:
+        'List published mountaineering ascent reports (گزارش صعود) on kavehrs.com. Optional query filters by title or description.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Optional search text in Persian or English' }
+        }
+      },
+      annotations: { readOnlyHint: true },
+      execute: async function (args) {
+        return JSON.stringify(filterItems(catalog.logbook || [], args && args.query));
+      }
+    });
+
+    await ctx.registerTool({
+      name: 'list_notes',
+      description:
+        'List published technical notes (یادداشت‌ها) on kavehrs.com. Optional query filters by title or description.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Optional search text in Persian or English' }
+        }
+      },
+      annotations: { readOnlyHint: true },
+      execute: async function (args) {
+        return JSON.stringify(filterItems(catalog.blog || [], args && args.query));
+      }
+    });
+
+    await ctx.registerTool({
+      name: 'get_current_page',
+      description: 'Return the current page path, title, and kind (home, ascent_report, note, or page).',
+      inputSchema: { type: 'object', properties: {} },
+      annotations: { readOnlyHint: true },
+      execute: async function () {
+        return JSON.stringify(currentPage());
+      }
+    });
+
+    await ctx.registerTool({
+      name: 'open_page',
+      description:
+        'Open a same-site page: /, /logbook/, /blog/, or a published report/note URL from the catalog.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Site path such as /, /logbook/, /blog/, or a catalog URL'
+          }
+        },
+        required: ['path']
+      },
+      annotations: { readOnlyHint: false },
+      execute: async function (args) {
+        var path = args && args.path;
+        if (!allowedPath(path, catalog)) {
+          return 'Refused: path is not a published page on this site.';
+        }
+        window.location.assign(path);
+        return 'Opening ' + path;
+      }
+    });
+  }
+
+  var ctx = modelContext();
+  if (!ctx) return;
+
+  fetch('/webmcp-catalog.json', { credentials: 'same-origin' })
+    .then(function (response) {
+      if (!response.ok) throw new Error('catalog');
+      return response.json();
+    })
+    .then(register)
+    .catch(function () {});
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
WebMCP روی این سایت استاتیک کامل پیاده نمی‌شود (فرم تعاملی، origin trial مرورگر، هدر Permissions-Policy در GitHub Pages نیست). این تغییر همان بخشی را می‌گذارد که برای گزارش صعود و یادداشت‌ها معنا دارد:

- اگر مرورگر `document.modelContext` داشته باشد، چهار ابزار ثبت می‌شود: فهرست گزارش‌ها، فهرست یادداشت‌ها، صفحهٔ جاری، باز کردن مسیر هم‌سایت
- کاتالوگ از `/webmcp-catalog.json` می‌آید (خارج از sitemap)
- بازدیدکننده‌های معمولی فقط یک اسکریپت کوچک می‌گیرند؛ کاتالوگ فقط وقتی API وجود داشته باشد fetch می‌شود

همزمان عکس یادداشت «کوهنوردی، یک رفت و برگشت…» که در ریپو به‌صورت `Cover.jpg` آمده به کاور و بالای متن وصل شد.

`bundle exec jekyll build` بدون خطا تمام شد.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15004a70-f5b2-401a-b25e-d92b8f563c9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15004a70-f5b2-401a-b25e-d92b8f563c9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

