### PR TITLE
Add blog news kind (اخبار) with /news/ hub

### DIFF
--- a/.cursor/automations/blog-post-prompt.md
+++ b/.cursor/automations/blog-post-prompt.md
@@ -40,6 +40,13 @@ Mission: create or update Persian technical notes in `_blog/` from the default t
 7. Write as the author (من). No agent notes on the live page.
 8. Reader-facing dates are Jalali via _includes/jalali-date.html.
 
+## When the user asks for an خبر / news item
+
+1. Same `_blog/` collection with kind: news and permalink: /news/:path/
+2. Use _drafts/news-post-template.md (short; do not use technical-note sections)
+3. Images under assets/news/YYYY-MM-DD-<slug>/
+4. Do not invent events. Hub /news/ lists these; /blog/ does not.
+
 ## Do not
 
 - Put this content in `_logbook/`

--- a/.cursor/automations/daily-seo-prompt.md
+++ b/.cursor/automations/daily-seo-prompt.md
@@ -27,7 +27,7 @@ Before changing anything:
 3. Obey .cursor/rules/seo-daily-agent.mdc and .cursor/rules/logbook-reports.mdc
 4. Refresh guidance from Google Search Central, Bing Webmaster Guidelines, and schema.org (latest public docs)
 
-Then audit the live site + repo (every `/logbook/` and `/blog/` URL in the sitemap), implement only evidence-based SEO improvements (logbook first, then blog), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
+Then audit the live site + repo (every `/logbook/`, `/blog/`, and `/news/` URL in the sitemap), implement only evidence-based SEO improvements (logbook first, then blog/news), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
 
 If you make verified high-confidence changes: open a PR on a cursor/*-33ce branch and merge to master after a clean build.
 If nothing material needs changing: do not open a PR; leave a brief summary of what you checked.

--- a/.cursor/rules/blog-posts.mdc
+++ b/.cursor/rules/blog-posts.mdc
@@ -1,17 +1,17 @@
 ---
 description: Default template and rules for technical notes in `_blog/` (پست جدید وبلاگ)
-globs: _blog/**, _drafts/blog-post-template.md
+globs: _blog/**, _drafts/blog-post-template.md, _drafts/news-post-template.md
 alwaysApply: false
 ---
 
 # Blog notes — default post template
 
-When the user asks for a new blog post (`پست جدید وبلاگ` / یادداشت جدید / آپدیت یادداشت فنی), act as the **blog-post agent**.
+When the user asks for a new blog post (`پست جدید وبلاگ` / یادداشت جدید / آپدیت یادداشت فنی / خبر / اخبار), act as the **blog-post agent**.
 
 ## Entry points
 
 1. Follow `.cursor/skills/blog-post/SKILL.md`
-2. Use `_drafts/blog-post-template.md` (structure only — never republish its placeholders)
+2. Use `_drafts/blog-post-template.md` for notes, or `_drafts/news-post-template.md` for `kind: news`
 3. Automation prompt: `.cursor/automations/blog-post-prompt.md`
 
 Instagram imports into `_blog/` use this same file shape via the Instagram agent (`.cursor/agents/instagram.md`) plus `.cursor/skills/instagram-to-blog/SKILL.md`. Do not send those notes through this rule’s technical-post template sections.
@@ -19,7 +19,8 @@ Instagram imports into `_blog/` use this same file shape via the Instagram agent
 ## File and URL
 
 - New file: `_blog/YYYY-MM-DD-<slug>.md` with **zero-padded** month and day
-- Collection permalink is `/blog/:path/` → URL = `/blog/YYYY-MM-DD-<slug>/`
+- Collection permalink is `/blog/:path/` → URL = `/blog/YYYY-MM-DD-<slug>/` for notes
+- News: same collection, `kind: news` + `permalink: /news/:path/` → `/news/YYYY-MM-DD-<slug>/`
 - Do **not** rename existing posts (legacy paths like `2020-9-16-Clean-Code` stay)
 - Do **not** overwrite or dilute published `_blog/` / `_logbook/` body copy when collecting “latest materials”. Put research in `_seo/watch-inbox.md`. A new note is a new file. Never paste other clubs’ reports into an existing post.
 
@@ -33,6 +34,9 @@ dir_attr: rtl
 description: "…"   # unique, ~120–160 chars
 date: YYYY-MM-DD  # Gregorian; UI Jalali via jalali-date.html
 tags: [موضوع, ابزار]  # YAML array only
+# kind: note is the default (یادداشت). For اخبار set:
+# kind: news
+# permalink: /news/:path/
 ```
 
 Optional:
@@ -48,8 +52,9 @@ Comment `image` out until the owner provides the file. Do not point OG at a miss
 
 ## Images
 
-- New posts: `assets/blog/<exact-url-slug>/` matching `/blog/<slug>/`
-- Markdown: `/assets/blog/<slug>/<file>` with a meaningful Persian `alt`
+- Notes: `assets/blog/<exact-url-slug>/` matching `/blog/<slug>/`
+- News: `assets/news/<exact-url-slug>/` matching `/news/<slug>/`
+- Markdown paths with a meaningful Persian `alt`
 - If photos are not ready: keep the folder with `.gitkeep` and leave `image:` commented
 
 ## Body
@@ -66,10 +71,11 @@ Write as the author (من). No agent notes, no JSON-LD talk, no «این بند 
 
 ## Related and hub
 
-- Fill `related` from real sibling posts (same series or shared tags)
-- Public UI: heading `یادداشت‌های مرتبط :` + flat list (`_includes/related-links.html`)
-- Hub `/blog/` is chronological (newest first)
-- Homepage `/` is filled automatically from the 4 newest blog notes and 4 newest logbook reports (`_includes/home-latest.html`). Do not edit `index.md` teasers.
+- Fill `related` from real sibling posts (same series or shared tags; news only matches other news)
+- Public UI: heading `یادداشت‌های مرتبط :` or `اخبار مرتبط :` + flat list (`_includes/related-links.html`)
+- Hub `/blog/` lists **notes only**, chronological (newest first)
+- Hub `/news/` lists **news only**, chronological
+- Homepage `/` is filled automatically from the 4 newest notes, 4 newest logbook reports, and 4 newest news items (`_includes/home-latest.html`). The news column is omitted until the first news post exists. Do not edit `index.md` teasers.
 
 ## Facts
 

--- a/.cursor/skills/blog-post/SKILL.md
+++ b/.cursor/skills/blog-post/SKILL.md
@@ -5,7 +5,7 @@ description: Agent skill for Persian یادداشت وبلاگ — new/update te
 
 # Blog post skill
 
-Use when the user asks for a **پست جدید وبلاگ** / یادداشت جدید / technical blog note / update to an existing `_blog/` post.
+Use when the user asks for a **پست جدید وبلاگ** / یادداشت جدید / technical blog note / **خبر** / news item / update to an existing `_blog/` post.
 
 The **Instagram agent** (`.cursor/agents/instagram.md`) also follows this skill for `_blog/` file shape when converting `imkavehrs` posts. Instagram sources, parser, and ledger stay in `.cursor/skills/instagram-to-blog/SKILL.md`.
 
@@ -29,10 +29,21 @@ Instagram agent: `.cursor/agents/instagram.md`
 4. `image:` only when a real asset exists; otherwise comment it out until the owner adds files
 5. Images in `assets/blog/YYYY-MM-DD-<slug>/` matching the URL path (`.gitkeep` if photos come later)
 6. Body from the template sections — rewrite all prose; never ship placeholders like `{{عنوان}}`
-7. Hub `/blog/` stays chronological; related UI = `یادداشت‌های مرتبط :` + flat list
-8. Homepage `/` always lists the **4 newest** `_blog/` and `_logbook/` items via `_includes/home-latest.html` — do **not** hardcode teasers in `index.md`
+7. Hub `/blog/` stays chronological (notes only); related UI = `یادداشت‌های مرتبط :` + flat list
+8. Homepage `/` lists the **4 newest** notes, **4 newest** logbook reports, and **4 newest** news items (`kind: news`) via `_includes/home-latest.html` — do **not** hardcode teasers in `index.md`. The news column is omitted until the first news post exists.
 9. If `image:` is set, the post layout shows it at the top of the note (and as OG cover)
 10. `bundle exec jekyll build` must succeed; `_drafts/` must not appear in `_site/`
+
+## News (`kind: news`)
+
+When the user asks for an **خبر** / news item (not a technical note):
+
+1. Same `_blog/YYYY-MM-DD-<slug>.md` collection, but set `kind: news` and `permalink: /news/:path/`
+2. Use `_drafts/news-post-template.md` (short announcement; do not use the technical-note sections)
+3. Images in `assets/news/YYYY-MM-DD-<slug>/` matching `/news/<slug>/`
+4. Hub `/news/` chronological; related UI = `اخبار مرتبط :` + flat list of other news only
+5. Do not list news on `/blog/`. Do not put news in `_logbook/`
+6. Do not invent events; omit rather than guess
 
 ## Voice and facts
 
@@ -45,6 +56,7 @@ Instagram agent: `.cursor/agents/instagram.md`
 
 - Put blog notes in `_logbook/`
 - Use logbook `categories` / `peak` / weather blocks on blog posts
+- Put `kind: news` on a technical tutorial (use the news template instead)
 - Rename old `_blog/` files (live URLs must stay)
 - Keyword-stuff titles
 - Publish agent/USAGE comments into the live page

--- a/.cursor/skills/daily-seo-audit/SKILL.md
+++ b/.cursor/skills/daily-seo-audit/SKILL.md
@@ -17,7 +17,7 @@ Improve discoverability of Persian **گزارش برنامه صعود** content 
 
 Hub `/logbook/` is chronological. Related blocks must stay a flat `گزارش‌های مرتبط :` list (no agent blurbs / category subheads on the page). Reader-facing dates stay Jalali (`_includes/jalali-date.html`), not English Gregorian.
 
-Primary hub: `/logbook/` · Technical notes: `/blog/` · Site: `https://www.kavehrs.com`
+Primary hub: `/logbook/` · Technical notes: `/blog/` · News: `/news/` · Site: `https://www.kavehrs.com`
 
 Every published post (logbook and blog) should be crawlable, have unique title/description, correct `lang`/`dir`, valid canonical, and useful structured data. Ranking “#1 for everything” is not a switch — compound people-first reports + technical hygiene + owner actions (Search Console, Bing, DNS trust). Do not keyword-stuff.
 
@@ -48,7 +48,7 @@ Record: title, meta description, canonical, `lang`/`dir`, H1 count, OG/Twitter t
 
 ## Step 2 — Repo audit checklist
 
-For each `_logbook/*.md`, `_blog/*.md`, and key pages (`index.md`, `logbook.md`, blog index):
+For each `_logbook/*.md`, `_blog/*.md`, and key pages (`index.md`, `logbook.md`, blog index, news index):
 
 - [ ] Unique `title` and `description` (≈120–160 chars for description when practical)
 - [ ] `lang` / `dir_attr` correct

--- a/.cursor/skills/instagram-to-blog/SKILL.md
+++ b/.cursor/skills/instagram-to-blog/SKILL.md
@@ -67,6 +67,7 @@ For every item **not** already in `_data/instagram_imports.yml`:
    - unique `title` + `description` (~120–160 chars)
    - `date: YYYY-MM-DD`
    - `tags: [YAML array]` from real topics in the caption (strip spam hashtags)
+   - omit `kind` (defaults to note / یادداشت). Do not set `kind: news` unless the owner said the item is an announcement
    - `source: instagram`
    - `instagram_url` / `instagram_shortcode` when known
    - `image:` only after a real file is copied into `assets/blog/<slug>/`

--- a/.cursor/skills/logbook-ascent-report/SKILL.md
+++ b/.cursor/skills/logbook-ascent-report/SKILL.md
@@ -43,7 +43,7 @@ Use `_drafts/samples/kahar-peak-report-framework-sample.md` only as structure �
 6. `assets/mount/logbook/<exact-url-slug>/` for all images
 7. Narrative outline → post-climb completion when user provides details. Program length from user only (Kahar = one-day ۱۶ مرداد ۱۴۰۵ unless changed).
 8. Hub `/logbook/` chronological; related UI = only `گزارش‌های مرتبط :` + flat list
-9. Homepage `/` always lists the 4 newest reports via `_includes/home-latest.html` (do not hardcode teasers in `index.md`)
+9. Homepage `/` always lists the 4 newest reports (and notes/news via the same include) via `_includes/home-latest.html` (do not hardcode teasers in `index.md`)
 10. Never publish agent notes in live HTML
 11. Reader-facing UI dates Jalali (`_includes/jalali-date.html`)
 

--- a/.github/workflows/daily-seo-agent.yml
+++ b/.github/workflows/daily-seo-agent.yml
@@ -41,7 +41,7 @@ jobs:
           3. Obey .cursor/rules/seo-daily-agent.mdc and .cursor/rules/logbook-reports.mdc
           4. Refresh guidance from Google Search Central, Bing Webmaster Guidelines, and schema.org (latest public docs)
 
-          Then audit the live site + repo (every /logbook/ and /blog/ URL), implement only evidence-based SEO improvements (logbook first, then blog), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
+          Then audit the live site + repo (every /logbook/, /blog/, and /news/ URL), implement only evidence-based SEO improvements (logbook first, then blog/news), append a short entry to _seo/daily-log.md, run `bundle exec jekyll build`, and confirm drafts/.cursor are unpublished.
 
           If you make verified high-confidence changes: open a PR on a cursor/*-33ce branch and merge to master after a clean build.
           If nothing material needs changing: do not open a PR; leave a brief summary of what you checked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,10 @@ When asked for a `پست جدید وبلاگ` / یادداشت فنی / update t
 1. Follow `.cursor/skills/blog-post/SKILL.md`.
 2. Obey `.cursor/rules/blog-posts.mdc`.
 3. Use `_drafts/blog-post-template.md` (structure only — never publish placeholders).
-4. File: `_blog/YYYY-MM-DD-<slug>.md` with zero-padded date, `lang: fa-IR`, YAML `tags` array, unique description.
+4. File: `_blog/YYYY-MM-DD-<slug>.md` with zero-padded date, `lang: fa-IR`, YAML `tags` array, unique description. For اخبار set `kind: news` and `permalink: /news/:path/` (template `_drafts/news-post-template.md`); notes omit `kind` or use `kind: note`.
 5. Images for new notes: `assets/blog/<exact-url-slug>/`; comment `image:` out until files exist.
-6. Related UI stays `یادداشت‌های مرتبط :` + flat list. Hub `/blog/` chronological.
-7. Homepage `/` lists the 4 newest notes and reports automatically; do not hardcode teasers in `index.md`.
+6. Related UI stays `یادداشت‌های مرتبط :` + flat list for notes. News uses `اخبار مرتبط :`. Hub `/blog/` chronological notes only; hub `/news/` chronological news only.
+7. Homepage `/` lists the 4 newest notes, 4 newest reports, and 4 newest news items automatically; do not hardcode teasers in `index.md`. The news column appears only after the first `kind: news` post.
 8. For a Cursor Automation, paste `.cursor/automations/blog-post-prompt.md` at https://cursor.com/automations/new
 9. Open a PR on `cursor/<descriptive-name>-33ce`, verify `bundle exec jekyll build`.
 
@@ -132,7 +132,7 @@ When running the scheduled SEO automation (or when asked to audit SEO):
 1. Follow `.cursor/skills/daily-seo-audit/SKILL.md` end-to-end.
 2. Obey `.cursor/rules/seo-daily-agent.mdc` and `.cursor/rules/logbook-reports.mdc`.
 3. Prefer high-confidence technical SEO and discoverability fixes over speculative copy rewrites.
-4. Audit every published `/logbook/` and `/blog/` URL (unique title/description, canonical, structured data) — logbook first.
+4. Audit every published `/logbook/`, `/blog/`, and `/news/` URL (unique title/description, canonical, structured data) — logbook first.
 5. Never republish duplicate report prose for the same peak.
 6. Open a PR on `cursor/<descriptive-name>-33ce`, verify `bundle exec jekyll build`, then merge to `master` when changes are safe and verified.
 

--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,7 @@ defaults:
       type: blog
     values:
       layout: post
+      kind: note
   - scope:
       path: ""
       type: logbook

--- a/_data/blog_kinds.yml
+++ b/_data/blog_kinds.yml
@@ -1,0 +1,19 @@
+# Blog post kinds (front matter `kind:` on `_blog/*.md`).
+# Default when omitted: note (یادداشت).
+# news = اخبار — short announcements, not technical notes and not logbook reports.
+# Related UI stays a flat list (notes: «یادداشت‌های مرتبط :» / news: «اخبار مرتبط :»).
+# Hub `/blog/` lists notes only. Hub `/news/` lists news only. Both chronological (newest first).
+# News posts must set permalink: /news/:path/ so URLs are /news/YYYY-MM-DD-slug/
+# Images for news: assets/news/<exact-url-slug>/ matching /news/<slug>/
+
+order:
+  - note
+  - news
+
+labels:
+  note: یادداشت‌ها
+  news: اخبار
+
+hubs:
+  note: /blog/
+  news: /news/

--- a/_drafts/blog-post-template.md
+++ b/_drafts/blog-post-template.md
@@ -24,6 +24,7 @@ USAGE (agent-only — do not copy this comment block into published pages)
    description (unique, ~120–160 chars, not keyword-stuffed)
    date: YYYY-MM-DD (Gregorian for machines; UI shows Jalali)
    tags: [YAML array] — never a single unquoted string
+   kind: omit or `note` for یادداشت; `news` is a different template (`_drafts/news-post-template.md`)
 3) Optional:
    related: [{ title, url }] for a series (manual list wins over tag matching)
    image: only a real photo/diagram for THIS note
@@ -32,7 +33,7 @@ USAGE (agent-only — do not copy this comment block into published pages)
    Reference as `/assets/blog/YYYY-MM-DD-<slug>/<file>` with a Persian alt
 5) Related UI is selected by `page.related` or shared tags.
    Public heading: «یادداشت‌های مرتبط :» + flat list only
-6) Hub `/blog/` is chronological by date (newest first)
+6) Hub `/blog/` is chronological by date (newest first) and lists notes only — news items (`kind: news`) go to `/news/`
 7) Write as the author (من). Never publish agent notes, JSON-LD asides, or «این بند برای SEO»
 8) Do not invent commands, version numbers, IPs, or results the user did not give
 9) If the note is version-dated (e.g. Zabbix 5, GOPATH-era Go), say so in the lead

--- a/_drafts/news-post-template.md
+++ b/_drafts/news-post-template.md
@@ -1,0 +1,42 @@
+---
+# DRAFT TEMPLATE — not published
+# چهارچوب خبر کوتاه وبلاگ (kind: news)
+# هنگام ساخت خبر جدید: این سکشن‌ها را نگه دار، متن را از نو بنویس.
+layout: null
+title: "قالب خبر وبلاگ — درفت"
+published: false
+sitemap: false
+noindex: true
+lang: fa-IR
+dir_attr: rtl
+---
+
+<!--
+USAGE (agent-only — do not copy this comment block into published pages)
+0) News items live in `_blog/` with front matter kind: news
+   Template for notes is `_drafts/blog-post-template.md` — do not mix the two
+1) Copy structure into `_blog/YYYY-MM-DD-<slug>.md` (zero-pad month and day)
+2) Front matter required:
+   layout: post
+   kind: news
+   permalink: /news/:path/
+   title, lang: fa-IR, dir_attr: rtl
+   description (unique, ~120–160 chars, not keyword-stuffed)
+   date: YYYY-MM-DD (Gregorian for machines; UI shows Jalali)
+   tags: [YAML array]
+3) Optional related: [{ title, url }] only to other news items when they exist
+   image: only a real photo for THIS item; comment out until the file exists
+4) Images: `assets/news/YYYY-MM-DD-<slug>/` matching `/news/YYYY-MM-DD-<slug>/`
+5) Related public UI: «اخبار مرتبط :» + flat list
+6) Hub `/news/` is chronological (newest first). `/blog/` must not list news.
+7) Write as the author (من). Short: what happened, why it matters, optional link
+   to an existing `/logbook/` report or `/blog/` note — do not clone a climb report
+8) Do not invent events, dates, or team names the user did not give
+9) Never paste this template prose unchanged into a published post
+-->
+
+{{یک پاراگراف: این خبر چیست و چرا الان نوشته شده}}
+
+{{جزئیات کوتاه — فقط واقعیت‌هایی که کاربر داده}}
+
+<!-- optional: لینک به گزارش صعود یا یادداشت موجود -->

--- a/_includes/home-latest.html
+++ b/_includes/home-latest.html
@@ -1,10 +1,12 @@
 {% comment %}
-Homepage teasers: four newest logbook reports and four newest blog notes.
-Do not hardcode titles in index.md — this include is the source of truth.
+Homepage teasers: four newest logbook reports, four newest notes, and four newest
+news items (kind: news). Do not hardcode titles in index.md.
+News column is omitted until at least one news post exists (avoids an empty third column).
 {% endcomment %}
 {% assign latest_logbook = site.logbook | sort: 'date' | reverse %}
-{% assign latest_blog = site.blog | sort: 'date' | reverse %}
-<div class="home-columns">
+{% assign latest_notes = site.blog | where_exp: "post", "post.kind != 'news'" | sort: 'date' | reverse %}
+{% assign latest_news = site.blog | where_exp: "post", "post.kind == 'news'" | sort: 'date' | reverse %}
+<div class="home-columns{% if latest_news.size > 0 %} home-columns--three{% endif %}">
   <div class="home-column">
     <h2><a href="{{ '/logbook/' | relative_url }}">گزارش صعود</a></h2>
     <ul>
@@ -16,9 +18,19 @@ Do not hardcode titles in index.md — this include is the source of truth.
   <div class="home-column">
     <h2><a href="{{ '/blog/' | relative_url }}">یادداشت‌ها</a></h2>
     <ul>
-      {% for post in latest_blog limit: 4 %}
+      {% for post in latest_notes limit: 4 %}
       <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
       {% endfor %}
     </ul>
   </div>
+  {% if latest_news.size > 0 %}
+  <div class="home-column">
+    <h2><a href="{{ '/news/' | relative_url }}">اخبار</a></h2>
+    <ul>
+      {% for post in latest_news limit: 4 %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
 </div>

--- a/_includes/hub-filter.html
+++ b/_includes/hub-filter.html
@@ -1,5 +1,5 @@
 {% comment %}
-Client-side list filter for /logbook/ and /blog/. Also exposes a WebMCP declarative form tool.
+Client-side list filter for /logbook/, /blog/, and /news/. Also exposes a WebMCP declarative form tool.
 {% endcomment %}
 {% if include.toolname and include.tooldescription %}
 <form class="hub-filter" method="get" action="{{ page.url | relative_url }}" toolname="{{ include.toolname }}" tooldescription="{{ include.tooldescription }}">

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,6 @@
 <nav>
-  <a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>خانه</a>  |   
-  <a href="{{ '/blog/' | relative_url }}" {% if page.url contains '/blog/' %}class="active"{% endif %}>یادداشت‌ها</a>   |   
+  <a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>خانه</a>  |
+  <a href="{{ '/blog/' | relative_url }}" {% if page.url contains '/blog/' and page.kind != 'news' %}class="active"{% endif %}>یادداشت‌ها</a>  |
+  <a href="{{ '/news/' | relative_url }}" {% if page.kind == 'news' or page.url == '/news/' %}class="active"{% endif %}>اخبار</a>  |
   <a href="{{ '/logbook/' | relative_url }}" {% if page.url contains '/logbook/' %}class="active"{% endif %}>گزارش صعود</a>
 </nav>

--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,12 +1,23 @@
 {% comment %}
 Related links:
 - Logbook: SELECT by shared disciplines; public UI «گزارش‌های مرتبط :» + flat list.
-- Blog: manual page.related, else shared tags; public UI «یادداشت‌های مرتبط :» + flat list.
+- Notes (kind != news): manual page.related, else shared tags; «یادداشت‌های مرتبط :»
+- News (kind == news): same, but only other news; «اخبار مرتبط :»
 Manual page.related still wins when provided.
 {% endcomment %}
+{% assign page_is_news = false %}
+{% if page.kind == 'news' %}
+  {% assign page_is_news = true %}
+{% endif %}
+{% assign related_heading = 'یادداشت‌های مرتبط' %}
+{% if page.collection == 'logbook' %}
+  {% assign related_heading = 'گزارش‌های مرتبط' %}
+{% elsif page_is_news %}
+  {% assign related_heading = 'اخبار مرتبط' %}
+{% endif %}
 {% if page.related and page.related.size > 0 %}
-<nav class="related-posts" aria-label="{% if page.collection == 'logbook' %}گزارش‌های مرتبط{% else %}یادداشت‌های مرتبط{% endif %}" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
-  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">{% if page.collection == 'logbook' %}گزارش‌های مرتبط :{% else %}یادداشت‌های مرتبط :{% endif %}</h2>
+<nav class="related-posts" aria-label="{{ related_heading }}" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
+  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">{{ related_heading }} :</h2>
   <ul>
     {% for item in page.related %}
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
@@ -66,7 +77,11 @@ Manual page.related still wins when provided.
 {% elsif page.collection == 'blog' and page.tags and page.tags.size > 0 %}
   {% assign ranked_entries = '' %}
   {% for post in site.blog %}
-    {% if post.url != page.url and post.tags %}
+    {% assign post_is_news = false %}
+    {% if post.kind == 'news' %}
+      {% assign post_is_news = true %}
+    {% endif %}
+    {% if post.url != page.url and post.tags and page_is_news == post_is_news %}
       {% assign overlap = 0 %}
       {% for tag in page.tags %}
         {% if post.tags contains tag %}
@@ -97,8 +112,8 @@ Manual page.related still wins when provided.
     {% endif %}
   {% endfor %}
   {% if related_count > 0 %}
-<nav class="related-posts" aria-label="یادداشت‌های مرتبط" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
-  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">یادداشت‌های مرتبط :</h2>
+<nav class="related-posts" aria-label="{{ related_heading }}" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
+  <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem;">{{ related_heading }} :</h2>
   <ul>{{ related_items }}</ul>
 </nav>
   {% endif %}

--- a/_includes/structured-data-logbook.html
+++ b/_includes/structured-data-logbook.html
@@ -45,8 +45,8 @@
     {
       "@type": "ListItem",
       "position": 2,
-      "name": "{% if page.collection == 'logbook' %}گزارش صعود{% else %}یادداشت‌ها{% endif %}",
-      "item": "{% if page.collection == 'logbook' %}{{ '/logbook/' | absolute_url }}{% else %}{{ '/blog/' | absolute_url }}{% endif %}"
+      "name": "{% if page.collection == 'logbook' %}گزارش صعود{% elsif page.kind == 'news' %}اخبار{% else %}یادداشت‌ها{% endif %}",
+      "item": "{% if page.collection == 'logbook' %}{{ '/logbook/' | absolute_url }}{% elsif page.kind == 'news' %}{{ '/news/' | absolute_url }}{% else %}{{ '/blog/' | absolute_url }}{% endif %}"
     },
     {
       "@type": "ListItem",
@@ -153,6 +153,7 @@
 {% endif %}
 
 {% if page.url == '/blog/' %}
+{% assign notes = site.blog | where_exp: "post", "post.kind != 'news'" | sort: "date" | reverse %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -175,9 +176,46 @@
   ],
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": {{ site.blog.size }},
+    "numberOfItems": {{ notes.size }},
     "itemListElement": [
-      {% for post in site.blog reversed %}
+      {% for post in notes %}
+      {
+        "@type": "ListItem",
+        "position": {{ forloop.index }},
+        "url": {{ post.url | absolute_url | jsonify }},
+        "name": {{ post.title | jsonify }}
+      }{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ]
+  }
+}
+</script>
+{% endif %}
+
+{% if page.url == '/news/' %}
+{% assign news_posts = site.blog | where_exp: "post", "post.kind == 'news'" | sort: "date" | reverse %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": {{ page.title | jsonify }},
+  "description": {{ page.description | jsonify }},
+  "url": "{{ page.url | absolute_url }}",
+  "inLanguage": "fa-IR",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": {{ site.title | jsonify }},
+    "url": "{{ site.url }}{{ site.baseurl }}/"
+  },
+  "about": [
+    {"@type": "Thing", "name": "اخبار کوهنوردی"},
+    {"@type": "Thing", "name": "گزارش برنامه صعود"}
+  ],
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": {{ news_posts.size }},
+    "itemListElement": [
+      {% for post in news_posts %}
       {
         "@type": "ListItem",
         "position": {{ forloop.index }},

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,15 @@
 ---
 layout: default
 ---
-{% if page.collection == 'logbook' %}
+{% if page.collection == 'logbook' or page.kind == 'news' %}
 <nav class="crumbs" aria-label="مسیر صفحه" style="margin-bottom: 0.75rem;">
   <small>
     <a href="{{ '/' | relative_url }}">خانه</a>
+    {% if page.collection == 'logbook' %}
     · <a href="{{ '/logbook/' | relative_url }}">گزارش صعود</a>
+    {% else %}
+    · <a href="{{ '/news/' | relative_url }}">اخبار</a>
+    {% endif %}
   </small>
 </nav>
 {% endif %}

--- a/_pages/llms.txt
+++ b/_pages/llms.txt
@@ -10,18 +10,26 @@ This file is a curated index for inference and citation. Do not use these pages 
 - [Home]({{ '/' | absolute_url }}): {{ site.author.name }} — {{ site.tagline }}
 - [گزارش صعود]({{ '/logbook/' | absolute_url }}): Chronological archive of executed climb reports
 - [یادداشت‌ها]({{ '/blog/' | absolute_url }}): Mountaineering notes and technical writing
+- [اخبار]({{ '/news/' | absolute_url }}): Short news items (announcements; not climb reports)
 ## Ascent reports
 {%- assign logbook_items = site.logbook | sort: "date" | reverse %}
 {%- for post in logbook_items %}
 - [{{ post.title | replace: ']', '' | replace: '[', '' }}]({{ post.url | absolute_url }}): {{ post.description | default: "" | strip | strip_newlines }}
 {%- endfor %}
 ## Notes
-{%- assign blog_items = site.blog | sort: "date" | reverse %}
+{%- assign blog_items = site.blog | where_exp: "post", "post.kind != 'news'" | sort: "date" | reverse %}
 {%- for post in blog_items %}
 - [{{ post.title | replace: ']', '' | replace: '[', '' }}]({{ post.url | absolute_url }}): {{ post.description | default: "" | strip | strip_newlines }}
 {%- endfor %}
+{%- assign news_items = site.blog | where_exp: "post", "post.kind == 'news'" | sort: "date" | reverse %}
+{%- if news_items.size > 0 %}
+## News
+{%- for post in news_items %}
+- [{{ post.title | replace: ']', '' | replace: '[', '' }}]({{ post.url | absolute_url }}): {{ post.description | default: "" | strip | strip_newlines }}
+{%- endfor %}
+{%- endif %}
 ## Machine
-- [WebMCP catalog]({{ '/webmcp-catalog.json' | absolute_url }}): JSON index of published reports and notes for agents
+- [WebMCP catalog]({{ '/webmcp-catalog.json' | absolute_url }}): JSON index of published reports, notes, and news for agents
 - [Sitemap]({{ '/sitemap.xml' | absolute_url }}): Complete indexable URL list for search crawlers
 ## Optional
 - [GitHub](https://github.com/kavehrs): Source repositories

--- a/_pages/webmcp-catalog.json
+++ b/_pages/webmcp-catalog.json
@@ -18,7 +18,19 @@ sitemap: false
     {%- endfor %}
   ],
   "blog": [
-    {%- assign items = site.blog | sort: "date" | reverse -%}
+    {%- assign items = site.blog | where_exp: "post", "post.kind != 'news'" | sort: "date" | reverse -%}
+    {%- for post in items %}
+    {
+      "title": {{ post.title | jsonify }},
+      "url": {{ post.url | jsonify }},
+      "date": {{ post.date | date: "%Y-%m-%d" | jsonify }},
+      "description": {{ post.description | default: "" | jsonify }},
+      "tags": {{ post.tags | jsonify }}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor %}
+  ],
+  "news": [
+    {%- assign items = site.blog | where_exp: "post", "post.kind == 'news'" | sort: "date" | reverse -%}
     {%- for post in items %}
     {
       "title": {{ post.title | jsonify }},

--- a/archive.html
+++ b/archive.html
@@ -11,4 +11,4 @@ dir_attr: rtl
 
 # بایگانی
 
-<p>برای مشاهده نوشته‌ها به <a href="{{ '/blog/' | relative_url }}">یادداشت‌ها</a> و برای گزارش‌های کوهنوردی به <a href="{{ '/logbook/' | relative_url }}">گزارش صعود</a> بروید.</p>
+<p>برای مشاهده نوشته‌ها به <a href="{{ '/blog/' | relative_url }}">یادداشت‌ها</a>، برای اخبار به <a href="{{ '/news/' | relative_url }}">اخبار</a> و برای گزارش‌های کوهنوردی به <a href="{{ '/logbook/' | relative_url }}">گزارش صعود</a> بروید.</p>

--- a/assets/css/_sass/profile.scss
+++ b/assets/css/_sass/profile.scss
@@ -73,6 +73,15 @@
   margin-top: 2lh;
 }
 
+.home-columns--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem 1.25rem;
+}
+
+.home-columns--three .home-column h2 {
+  font-size: 1.05rem;
+}
+
 .home-column h2 {
   font-size: 1.2rem;
   line-height: 1.45;
@@ -134,6 +143,10 @@
   padding-inline-start: 1.25rem;
   font-size: 0.95rem;
   line-height: $base-line-height;
+}
+
+.home-columns--three .home-column ul {
+  font-size: 0.88rem;
 }
 
 .home-column li + li {
@@ -228,7 +241,8 @@ html[dir="ltr"] article .home-column li {
     text-align: inherit;
   }
 
-  .home-columns {
+  .home-columns,
+  .home-columns--three {
     grid-template-columns: 1fr;
     gap: 1.5rem;
   }

--- a/assets/js/webmcp.js
+++ b/assets/js/webmcp.js
@@ -46,8 +46,8 @@
   function allowedPath(path, catalog) {
     if (!path || typeof path !== 'string' || path.charAt(0) !== '/') return false;
     if (path.indexOf('//') !== -1 || path.indexOf('\\') !== -1) return false;
-    if (path === '/' || path === '/logbook/' || path === '/blog/') return true;
-    var lists = (catalog.logbook || []).concat(catalog.blog || []);
+    if (path === '/' || path === '/logbook/' || path === '/blog/' || path === '/news/') return true;
+    var lists = (catalog.logbook || []).concat(catalog.blog || []).concat(catalog.news || []);
     for (var i = 0; i < lists.length; i++) {
       if (lists[i].url === path) return true;
     }
@@ -61,11 +61,13 @@
       kind:
         location.pathname.indexOf('/logbook/') === 0
           ? 'ascent_report'
-          : location.pathname.indexOf('/blog/') === 0
-            ? 'note'
-            : location.pathname === '/'
-              ? 'home'
-              : 'page'
+          : location.pathname.indexOf('/news/') === 0
+            ? 'news'
+            : location.pathname.indexOf('/blog/') === 0
+              ? 'note'
+              : location.pathname === '/'
+                ? 'home'
+                : 'page'
     };
   }
 
@@ -113,7 +115,7 @@
     await ctx.registerTool({
       name: 'search_site',
       description:
-        'Search published ascent reports and notes on kavehrs.com by title, description, tag, or category.',
+        'Search published ascent reports, notes, and news on kavehrs.com by title, description, tag, or category.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -126,7 +128,8 @@
         var query = args && args.query;
         return JSON.stringify({
           logbook: filterItems(catalog.logbook || [], query),
-          blog: filterItems(catalog.blog || [], query)
+          blog: filterItems(catalog.blog || [], query),
+          news: filterItems(catalog.news || [], query)
         });
       }
     });
@@ -149,6 +152,22 @@
     });
 
     await ctx.registerTool({
+      name: 'list_news',
+      description:
+        'List published news items (اخبار) on kavehrs.com. Optional query filters by title or description.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Optional search text in Persian or English' }
+        }
+      },
+      annotations: { readOnlyHint: true },
+      execute: async function (args) {
+        return JSON.stringify(filterItems(catalog.news || [], args && args.query));
+      }
+    });
+
+    await ctx.registerTool({
       name: 'get_note',
       description: 'Return one published note (یادداشت) by its site path, such as /blog/2026-08-18-mountaineering-return-knowledge/.',
       inputSchema: {
@@ -166,8 +185,25 @@
     });
 
     await ctx.registerTool({
+      name: 'get_news',
+      description: 'Return one published news item (اخبار) by its site path, such as /news/2026-08-19-example/.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Catalog URL path beginning with /news/' }
+        },
+        required: ['path']
+      },
+      annotations: { readOnlyHint: true },
+      execute: async function (args) {
+        var item = findByPath(catalog.news || [], args && args.path);
+        return item ? JSON.stringify(item) : 'Not found: path is not a published news item.';
+      }
+    });
+
+    await ctx.registerTool({
       name: 'get_current_page',
-      description: 'Return the current page path, title, and kind (home, ascent_report, note, or page).',
+      description: 'Return the current page path, title, and kind (home, ascent_report, note, news, or page).',
       inputSchema: { type: 'object', properties: {} },
       annotations: { readOnlyHint: true },
       execute: async function () {
@@ -178,13 +214,13 @@
     await ctx.registerTool({
       name: 'open_page',
       description:
-        'Open a same-site page: /, /logbook/, /blog/, or a published report/note URL from the catalog.',
+        'Open a same-site page: /, /logbook/, /blog/, /news/, or a published report/note/news URL from the catalog.',
       inputSchema: {
         type: 'object',
         properties: {
           path: {
             type: 'string',
-            description: 'Site path such as /, /logbook/, /blog/, or a catalog URL'
+            description: 'Site path such as /, /logbook/, /blog/, /news/, or a catalog URL'
           }
         },
         required: ['path']

--- a/news.md
+++ b/news.md
@@ -1,18 +1,21 @@
 ---
 layout: default
-title: یادداشت‌ها
-description: "یادداشت‌های کاوه‌ رضائی‌شیراز: کوهنوردی و یخ‌نوردی، به‌همراه آموزش‌های فنی برنامه‌نویسی، لینوکس و مانیتورینگ."
-permalink: /blog/
+title: اخبار
+description: "اخبار کوتاه کاوه‌ رضائی‌شیراز درباره برنامه‌های کوهنوردی، انتشار گزارش صعود و یادداشت‌ها."
+permalink: /news/
 lang: fa-IR
 dir_attr: rtl
 ---
 
-<h1>یادداشت‌ها</h1>
-<p>اینجا هم روایت برگشت به کوهستان را می‌نویسم، هم آموزش‌هایی که هنگام کار ثبت کرده‌ام: برنامه‌نویسی، لینوکس و مانیتورینگ.</p>
-{% assign notes = site.blog | where_exp: "post", "post.kind != 'news'" | sort: "date" | reverse %}
-{% include hub-filter.html toolname="filter_notes" tooldescription="Filter the published notes listed on this page by title or summary text." %}
+<h1>اخبار</h1>
+<p>اینجا خبرهای کوتاه را می‌نویسم: اعلام برنامه، انتشار گزارش صعود، یا نکته‌ای که یادداشت فنی نیست.</p>
+{% assign news_posts = site.blog | where_exp: "post", "post.kind == 'news'" | sort: "date" | reverse %}
+{% if news_posts.size == 0 %}
+<p>هنوز خبری در این بخش منتشر نشده است.</p>
+{% else %}
+{% include hub-filter.html toolname="filter_news" tooldescription="Filter the published news items listed on this page by title or summary text." %}
 <ul data-hub-list>
-  {% for post in notes %}
+  {% for post in news_posts %}
   <li style="margin-bottom: 15px; list-style: none; border-bottom: 1px solid #eee; padding-bottom: 10px;">
     <a href="{{ post.url }}" style="font-size: 1.2rem; font-weight: bold; text-decoration: none;">{{ post.title }}</a>
     {% if post.date %}
@@ -28,3 +31,4 @@ dir_attr: rtl
   </li>
   {% endfor %}
 </ul>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `kind: news` field on `_blog/` posts so اخبار is a third content stream, distinct from یادداشت‌ها.

- Default `kind: note` (existing posts unchanged)
- News posts: `kind: news` + `permalink: /news/:path/`
- Hub `/news/` (chronological); `/blog/` lists notes only
- Nav link «اخبار»
- Homepage third column **only after** the first news item exists (page stays two columns until then)
- Related UI: «اخبار مرتبط :» between news items; notes stay «یادداشت‌های مرتبط :»
- CollectionPage JSON-LD on `/news/`; blog ItemList excludes news
- WebMCP catalog `news` array + list/get tools

No sample news post is published (no invented events).

## SEO / UI note

Three homepage columns become justified once news has real items (three crawlable hubs). At 800px the third column stays slightly tight for long Persian titles; it stacks to one column below 660px.

## Verify

`bundle exec jekyll build` succeeded. `_drafts/` and `.cursor/` are unpublished.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59db3773-c848-431b-93d0-eff7e623d251?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59db3773-c848-431b-93d0-eff7e623d251&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

