### PR TITLE
حذف blog.kavehrs.com از DNS کلادفلر

### DIFF
--- a/_seo/daily-log.md
+++ b/_seo/daily-log.md
@@ -124,4 +124,8 @@ Owner follow-up left: Cloudflare Email Routing MX is present but routing is unco
 - Updated site/hub descriptions, CollectionPage `about`, `/llms.txt`, daily SEO skill/automation, and unpublished `_seo/authority-roadmap.md`.
 - Published note bodies were not rewritten.
 
+## 2026-08-21 — Remove blog.kavehrs.com from Cloudflare
+
+- Deleted DNS-only CNAME `blog.kavehrs.com` → `ghs.google.com` from zone `kavehrs.com`.
+- Do not recreate. Imported Blogger notes are on `/notes/`.
 

--- a/_seo/subdomain-dns-checklist.md
+++ b/_seo/subdomain-dns-checklist.md
@@ -29,7 +29,7 @@ The GitHub Pages site is served from `www.kavehrs.com` (or apex). These subdomai
 
 Live nameservers are `ken.ns.cloudflare.com` / `melina.ns.cloudflare.com`. API listing of the active zone shows **no** `pop`, `docs`, `tri`, or wildcard `*` records (NXDOMAIN). `www` is a proxied CNAME to `kavehrs.github.io`; apex 301s to `www`. Re-check if a wildcard or spam host reappears; do **not** recreate `*`.
 
-`blog.kavehrs.com` is a DNS-only CNAME to `ghs.google.com` (Blogger: «بریده هایی از دلمشغولی های من») — not the Jekyll site, not spam. Leave unless the owner wants it removed.
+`blog.kavehrs.com` CNAME to `ghs.google.com` was **deleted** 2026-08-21 (owner request). Do **not** recreate it. Personal notes from that Blogger live on `/notes/`.
 
 Mail: MX currently points at Cloudflare Email Routing, but routing status is `unconfigured` / disabled. ProtonMail verification TXT is also present. Owner should confirm inbound mail to `@kavehrs.com` actually arrives.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
رکورد DNS `blog.kavehrs.com` (CNAME به `ghs.google.com`) از زون کلادفلر `kavehrs.com` حذف شد.

این PR فقط یادداشت داخلی `_seo/` را به‌روز می‌کند تا آن CNAME دوباره ساخته نشود. مطالب منتقل‌شده روی `/notes/` هستند.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15004a70-f5b2-401a-b25e-d92b8f563c9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15004a70-f5b2-401a-b25e-d92b8f563c9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

